### PR TITLE
Remove extraneous github token

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -31,5 +31,4 @@ jobs:
         with:
           publish: npm run changeset-publish
         env:
-          GITHUB_TOKEN: ${{ secrets.GGITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
`GITHUB_TOKEN` is provided to workflows by default, no need to provide it ourselves