### PR TITLE
Add missing project references

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,11 +5,13 @@
   "files": [],
   "include": [],
   "references": [
-    { "path": "packages/dropUnusedDefinitions" },
     { "path": "packages/createHash" },
+    { "path": "packages/dropUnusedDefinitions" },
+    { "path": "packages/isNodeLike" },
     { "path": "packages/logger" },
     { "path": "packages/operationRegistrySignature" },
     { "path": "packages/printWithReducedWhitespace" },
+    { "path": "packages/sortAST" },
     { "path": "packages/stripSensitiveLiterals" }
   ]
 }


### PR DESCRIPTION
The top-level tsconfig is missing references to some of the packages, this adds the ones that are missing. Spotted by @glasser 🙇 