### PR TITLE
Fix entry points for new caching packages

### DIFF
--- a/.changeset/big-oranges-rush.md
+++ b/.changeset/big-oranges-rush.md
@@ -1,0 +1,6 @@
+---
+"@apollo/utils.keyvaluecache": patch
+"@apollo/utils.keyvadapter": patch
+---
+
+Add missing entry points for new caching packages

--- a/packages/keyValueCache/package.json
+++ b/packages/keyValueCache/package.json
@@ -2,6 +2,7 @@
   "name": "@apollo/utils.keyvaluecache",
   "version": "1.0.0",
   "description": "Minimal key-value cache interface",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",

--- a/packages/keyvAdapter/package.json
+++ b/packages/keyvAdapter/package.json
@@ -2,6 +2,7 @@
   "name": "@apollo/utils.keyvadapter",
   "version": "1.0.0",
   "description": "Keyv adapter implementing Apollo's KeyValueCache interface",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Whoops. I think I had originally intended the `keyvaluecache` package to be just types and forgot to add an entry point. Then copy/pasted that mistake into `keyvadapter`.