### PR TITLE
`KeyvAdapter`: Use `keyv`'s batching functionality

### DIFF
--- a/.changeset/healthy-dolls-film.md
+++ b/.changeset/healthy-dolls-film.md
@@ -1,0 +1,5 @@
+---
+"@apollo/utils.keyvadapter": minor
+---
+
+Support batch reads via Keyv's multi-key `get` function overload. Allow for users to opt out of this behavior via the `disableBatchReads` option.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8595,8 +8595,14 @@
       "license": "MIT",
       "dependencies": {
         "@apollo/utils.keyvaluecache": "^1.0.1",
+        "dataloader": "^2.1.0",
         "keyv": "^4.2.8"
       }
+    },
+    "packages/keyvAdapter/node_modules/dataloader": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.1.0.tgz",
+      "integrity": "sha512-qTcEYLen3r7ojZNgVUaRggOI+KM7jrKxXeSHhogh/TWxYMeONEMqY+hmkobiYQozsGIyg9OYVzO4ZIfoB4I0pQ=="
     },
     "packages/keyValueCache": {
       "name": "@apollo/utils.keyvaluecache",
@@ -8761,7 +8767,15 @@
       "version": "file:packages/keyvAdapter",
       "requires": {
         "@apollo/utils.keyvaluecache": "^1.0.1",
+        "dataloader": "^2.1.0",
         "keyv": "^4.2.8"
+      },
+      "dependencies": {
+        "dataloader": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.1.0.tgz",
+          "integrity": "sha512-qTcEYLen3r7ojZNgVUaRggOI+KM7jrKxXeSHhogh/TWxYMeONEMqY+hmkobiYQozsGIyg9OYVzO4ZIfoB4I0pQ=="
+        }
       }
     },
     "@apollo/utils.keyvaluecache": {

--- a/packages/keyvAdapter/README.md
+++ b/packages/keyvAdapter/README.md
@@ -35,3 +35,16 @@ new ApolloServer({
   cache: new KeyvAdapter(new Keyv("redis://...")),
 });
 ```
+
+## Options
+
+### disableBatchReads <boolean>
+
+By default, `KeyvAdapter` will use [`DataLoader`'s batching functionality](https://github.com/graphql/dataloader#batching) in order to request a list of keys when possible. Support for this depends on the `Keyv` implementation that you're using, specifically its `store` must implement a `getMany` function.
+
+For example, `Redis.Cluster` from `ioredis` does not support `mget`, so batching should be disabled like so:
+```ts
+new ApolloServer({
+  cache: new KeyvAdapter(new Keyv("redis://..."), { disableBatchReads: true }),
+});
+```

--- a/packages/keyvAdapter/package.json
+++ b/packages/keyvAdapter/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@apollo/utils.keyvaluecache": "^1.0.1",
+    "dataloader": "^2.1.0",
     "keyv": "^4.2.8"
   }
 }

--- a/packages/keyvAdapter/src/__tests__/KeyvAdapter.test.ts
+++ b/packages/keyvAdapter/src/__tests__/KeyvAdapter.test.ts
@@ -70,7 +70,15 @@ describe("KeyvAdapter", () => {
       expect(storeSetCalled).toBe(true);
     });
 
-    it("get", async () => {
+    it("get (batching enabled - default)", async () => {
+      const getSpy = jest.spyOn(keyv, "get");
+      const result = await keyvAdapter.get("foo");
+      expect(result).toBe(1);
+      expect(getSpy).toHaveBeenCalledWith(["foo"]);
+    });
+
+    it("get (batching disabled)", async () => {
+      const keyvAdapter = new KeyvAdapter(keyv, { disableBatchReads: true });
       const getSpy = jest.spyOn(keyv, "get");
       const result = await keyvAdapter.get("foo");
       expect(result).toBe(1);


### PR DESCRIPTION
KeyvAdapter now uses `keyv`'s batching functionality by default, by
calling `get` with an array of keys via `DataLoader`. This functionality
can be disabled by passing the `disableBatchReads: true` option to
`KeyvAdapter`.