### PR TITLE
fix(keyvAdapter): update generics to match Keyv

### DIFF
--- a/.changeset/giant-crabs-sing.md
+++ b/.changeset/giant-crabs-sing.md
@@ -1,0 +1,5 @@
+---
+"@apollo/utils.keyvadapter": patch
+---
+
+Adds typescript class generics to match Keyv class generics.

--- a/packages/keyvAdapter/src/__tests__/KeyvAdapter.test.ts
+++ b/packages/keyvAdapter/src/__tests__/KeyvAdapter.test.ts
@@ -26,6 +26,36 @@ describe("KeyvAdapter", () => {
     expectType<KeyValueCache<number>>(new KeyvAdapter(numberKeyv));
   });
 
+  it("Keyv class generics `Option`", () => {
+    interface RedisOption {
+      sentinels: {
+        port?: number;
+        host?: string;
+        family?: number;
+      }[];
+    }
+    const keyv = new Keyv<string, RedisOption>({
+      sentinels: [],
+    });
+    const keyvAdapter = new KeyvAdapter<string, RedisOption>(keyv);
+    expectType<KeyvAdapter<string, RedisOption>>(keyvAdapter);
+  });
+
+  it("Keyv class generics with incompatible `Option`", () => {
+    interface Option {
+      sentinels: {
+        port?: number;
+        host?: string;
+        family?: number;
+      }[];
+    }
+    const keyv = new Keyv<string, Option>({
+      sentinels: [],
+    });
+    // @ts-expect-error
+    new KeyvAdapter<string>(keyv);
+  });
+
   describe("Keyv methods", () => {
     let keyv: Keyv<number>;
     let keyvAdapter: KeyvAdapter<number>;

--- a/packages/keyvAdapter/src/__tests__/KeyvAdapter.test.ts
+++ b/packages/keyvAdapter/src/__tests__/KeyvAdapter.test.ts
@@ -41,6 +41,14 @@ describe("KeyvAdapter", () => {
     expectType<KeyvAdapter<string, RedisOption>>(keyvAdapter);
   });
 
+  it("Keyv class generics `Option` default", () => {
+    const keyv = new Keyv<string>({
+      sentinels: [],
+    });
+    const keyvAdapter = new KeyvAdapter<string>(keyv);
+    expectType<KeyvAdapter<string, Record<string, unknown>>>(keyvAdapter);
+  });
+
   it("Keyv class generics with incompatible `Option`", () => {
     interface Option {
       sentinels: {

--- a/packages/keyvAdapter/src/index.ts
+++ b/packages/keyvAdapter/src/index.ts
@@ -9,12 +9,12 @@ interface KeyvAdapterOptions {
   disableBatchReads?: boolean;
 }
 
-export class KeyvAdapter<V = string> implements KeyValueCache<V> {
-  private readonly keyv: Keyv<V>;
+export class KeyvAdapter<V = string, O extends Record<string, any> = Record<string, unknown>> implements KeyValueCache<V> {
+  private readonly keyv: Keyv<V, O>;
   private readonly dataLoader: DataLoader<string, V | undefined> | undefined;
 
-  constructor(keyv?: Keyv<V>, options?: KeyvAdapterOptions) {
-    this.keyv = keyv ?? new Keyv<V>();
+  constructor(keyv?: Keyv<V, O>, options?: KeyvAdapterOptions) {
+    this.keyv = keyv ?? new Keyv<V, O>();
     this.dataLoader = options?.disableBatchReads
       ? undefined
       : new DataLoader(

--- a/packages/keyvAdapter/src/index.ts
+++ b/packages/keyvAdapter/src/index.ts
@@ -9,7 +9,11 @@ interface KeyvAdapterOptions {
   disableBatchReads?: boolean;
 }
 
-export class KeyvAdapter<V = string, O extends Record<string, any> = Record<string, unknown>> implements KeyValueCache<V> {
+export class KeyvAdapter<
+  V = string,
+  O extends Record<string, any> = Record<string, unknown>,
+> implements KeyValueCache<V>
+{
   private readonly keyv: Keyv<V, O>;
   private readonly dataLoader: DataLoader<string, V | undefined> | undefined;
 


### PR DESCRIPTION
Hello,

This PR adds typescript class generics to match `Keyv` class generics. 
This is required to match typing for `Keyv` instances with generics such as `new Keyv<any, RedisOptions>(...)`

For example if initializing `KeyvAdapter` as:
```ts
import { KeyvAdapter } from '@apollo/utils.keyvadapter';
import Keyv from 'keyv';
import { RedisOptions } from 'ioredis';

new KeyvAdapter<any>(
  new Keyv<any, RedisOptions>('redis://user:pass@localhost:6379', {
    sentinels: [],
  }),
) 
```
typescript would complain as:
![image](https://user-images.githubusercontent.com/2078254/178931682-d88cf423-1f38-4462-bd3f-3bb452c18b90.png)

With this PR, `KeyvAdapter` can be initiated with generics as:
```ts
import { KeyvAdapter } from '@apollo/utils.keyvadapter';
import Keyv from 'keyv';
import { RedisOptions } from 'ioredis';

new KeyvAdapter<any, RedisOptions>( // <- changes
  new Keyv<any, RedisOptions>('redis://user:pass@localhost:6379', {
    sentinels: [],
  }),
)
```

The related type changes in `Keyv` was introduced in https://github.com/jaredwray/keyv/pull/272