### PR TITLE
Fix `dataloader` usage in `keyvadapter` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5857,8 +5857,9 @@
       }
     },
     "node_modules/keyv": {
-      "version": "4.2.8",
-      "license": "MIT",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.3.3.tgz",
+      "integrity": "sha512-AcysI17RvakTh8ir03+a3zJr5r0ovnAH/XTXei/4HIv3bL2K/jzvgivLK9UuI/JbU1aJjM3NSAnVvVVd3n+4DQ==",
       "dependencies": {
         "compress-brotli": "^1.3.8",
         "json-buffer": "3.0.1"
@@ -8543,7 +8544,7 @@
       "dependencies": {
         "@apollo/utils.keyvaluecache": "^1.0.1",
         "dataloader": "^2.1.0",
-        "keyv": "^4.2.8"
+        "keyv": "^4.3.3"
       }
     },
     "packages/keyvAdapter/node_modules/dataloader": {
@@ -8716,7 +8717,7 @@
       "requires": {
         "@apollo/utils.keyvaluecache": "^1.0.1",
         "dataloader": "^2.1.0",
-        "keyv": "^4.2.8"
+        "keyv": "^4.3.3"
       },
       "dependencies": {
         "dataloader": {
@@ -12898,7 +12899,9 @@
       }
     },
     "keyv": {
-      "version": "4.2.8",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.3.3.tgz",
+      "integrity": "sha512-AcysI17RvakTh8ir03+a3zJr5r0ovnAH/XTXei/4HIv3bL2K/jzvgivLK9UuI/JbU1aJjM3NSAnVvVVd3n+4DQ==",
       "requires": {
         "compress-brotli": "^1.3.8",
         "json-buffer": "3.0.1"

--- a/packages/keyvAdapter/package.json
+++ b/packages/keyvAdapter/package.json
@@ -20,6 +20,6 @@
   "dependencies": {
     "@apollo/utils.keyvaluecache": "^1.0.1",
     "dataloader": "^2.1.0",
-    "keyv": "^4.2.8"
+    "keyv": "^4.3.3"
   }
 }

--- a/packages/keyvAdapter/src/__tests__/KeyvAdapter.test.ts
+++ b/packages/keyvAdapter/src/__tests__/KeyvAdapter.test.ts
@@ -124,18 +124,18 @@ describe("KeyvAdapter", () => {
     });
 
     it("multiple `get`s are batched", async () => {
-      const storeWithGetMany: Store<number> = new (class extends Map<
+      const storeWithGetMany: Store<string> = new (class extends Map<
         string,
-        number
+        string
       > {
-        getMany = jest.fn((keys: string[]) =>
-          keys.map((key) => ({ value: this.get(key)!, expires: 0 })),
-        );
+        getMany = jest.fn((keys: string[]) => keys.map((key) => this.get(key)));
       })();
       const keyv = new Keyv({ store: storeWithGetMany });
       const keyvAdapter = new KeyvAdapter(keyv);
 
+      // @ts-ignore
       await keyvAdapter.set("foo", 1);
+      // @ts-ignore
       await keyvAdapter.set("bar", 2);
 
       const getSpy = jest.spyOn(keyv, "get");

--- a/packages/keyvAdapter/src/__tests__/KeyvAdapter.test.ts
+++ b/packages/keyvAdapter/src/__tests__/KeyvAdapter.test.ts
@@ -128,7 +128,9 @@ describe("KeyvAdapter", () => {
         string,
         number
       > {
-        getMany = jest.fn((keys: string[]) => keys.map((key) => this.get(key)));
+        getMany = jest.fn((keys: string[]) =>
+          keys.map((key) => ({ value: this.get(key)!, expires: 0 })),
+        );
       })();
       const keyv = new Keyv({ store: storeWithGetMany });
       const keyvAdapter = new KeyvAdapter(keyv);
@@ -143,8 +145,6 @@ describe("KeyvAdapter", () => {
       ]);
       expect(results).toEqual([1, 2]);
 
-      // @ts-expect-error - `Store.getMany` doesn't exist in Keyv types, even as an optional
-      // see https://github.com/jaredwray/keyv/pull/362
       expect(keyv["opts"]["store"]["getMany"]).toHaveBeenCalledWith([
         "keyv:foo",
         "keyv:bar",

--- a/packages/keyvAdapter/src/index.ts
+++ b/packages/keyvAdapter/src/index.ts
@@ -22,9 +22,7 @@ export class KeyvAdapter<
     this.dataLoader = options?.disableBatchReads
       ? undefined
       : new DataLoader(
-          (keys) =>
-            // @ts-expect-error Typings error in `keyv`, see: https://github.com/jaredwray/keyv/pull/359
-            this.keyv.get([...keys]),
+          async (keys) => Promise.all(await this.keyv.get([...keys])),
           // We're not actually using `DataLoader` for its caching
           // capabilities, we're only interested in batching functionality
           { cache: false },

--- a/packages/keyvAdapter/src/index.ts
+++ b/packages/keyvAdapter/src/index.ts
@@ -22,7 +22,7 @@ export class KeyvAdapter<
     this.dataLoader = options?.disableBatchReads
       ? undefined
       : new DataLoader(
-          async (keys) => Promise.all(await this.keyv.get([...keys])),
+          (keys) => this.keyv.get([...keys]),
           // We're not actually using `DataLoader` for its caching
           // capabilities, we're only interested in batching functionality
           { cache: false },


### PR DESCRIPTION
The `DataLoader` constructor expects a function which returns (effectively) a `Promise<Array<V>>`. Right now, as we have it, our function returns a `Promise<V>[]` (array of Promises) instead.

Not sure why TS didn't catch this (something to do with `dataloader`'s use of `PromiseLike` and `ArrayLike` that means our existing function somehow conforms to the signature?).

Fixes #166

TODO: add changeset and test reproduction