### PR TITLE
New package: @apollo/cache-control-types

### DIFF
--- a/.changeset/tiny-tools-invent.md
+++ b/.changeset/tiny-tools-invent.md
@@ -1,0 +1,5 @@
+---
+"@apollo/cache-control-types": major
+---
+
+New package, extracted from Apollo Server 4 alpha

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,10 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@apollo/cache-control-types": {
+      "resolved": "packages/cache-control-types",
+      "link": true
+    },
     "node_modules/@apollo/protobufjs": {
       "version": "1.2.2",
       "hasInstallScript": true,
@@ -8489,6 +8493,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "packages/cache-control-types": {
+      "name": "@apollo/cache-control-types",
+      "version": "1.0.0",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
     "packages/createHash": {
       "name": "@apollo/utils.createhash",
       "version": "1.1.0",
@@ -8666,6 +8678,10 @@
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.0"
       }
+    },
+    "@apollo/cache-control-types": {
+      "version": "file:packages/cache-control-types",
+      "requires": {}
     },
     "@apollo/protobufjs": {
       "version": "1.2.2",

--- a/packages/cache-control-types/.npmignore
+++ b/packages/cache-control-types/.npmignore
@@ -1,0 +1,7 @@
+*
+!src/**/*
+!dist/**/*
+dist/**/*.test.*
+!package.json
+!README.md
+!LICENSE

--- a/packages/cache-control-types/LICENSE
+++ b/packages/cache-control-types/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Apollo Graph, Inc. (Formerly Meteor Development Group, Inc.)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/cache-control-types/README.md
+++ b/packages/cache-control-types/README.md
@@ -1,0 +1,6 @@
+# Cache Control types
+
+This package exports various TypeScript types related to Apollo Server's cache
+policy calculation.
+
+Specifically, it gives a type-safe way to get the `info.cacheControl` field in resolvers. Either declare your resolver's `info` argument to be of type `GraphQLResolveInfoWithCacheControl` (perhaps with the graphql-code-generator typescript-resolvers customResolveInfo option), or use the `maybeCacheControlFromInfo` or `cacheControlFromInfo` functions to extract `info.cacheControl` in a type-safe way.

--- a/packages/cache-control-types/package.json
+++ b/packages/cache-control-types/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@apollo/cache-control-types",
+  "version": "0.0.0",
+  "description": "TypeScript types for Apollo Server info.cacheControl",
+  "types": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/apollographql/apollo-utils.git",
+    "directory": "packages/cache-control-types/"
+  },
+  "keywords": [
+    "apollo",
+    "graphql",
+    "typescript",
+    "node"
+  ],
+  "author": "Apollo <packages@apollographql.com>",
+  "license": "MIT",
+  "peerDependencies": {
+    "graphql": "14.x || 15.x || 16.x"
+  }
+}

--- a/packages/cache-control-types/src/index.ts
+++ b/packages/cache-control-types/src/index.ts
@@ -1,0 +1,102 @@
+// NOTE: Once Apollo Server 4 is released, move this package into the
+// apollo-server repo. We're placing it in the apollo-utils repo for now to
+// enable us to make non-alpha releases that can be used on the apollo-server
+// version-4 branch.
+
+import type { GraphQLCompositeType, GraphQLResolveInfo } from "graphql";
+
+/**
+ * CacheScope represents whether cacheable data should be shared across sessions
+ * (PUBLIC) or considered session-specific (PRIVATE).
+ */
+export type CacheScope = "PUBLIC" | "PRIVATE";
+
+/**
+ * CacheHint represents a contribution to an overall cache policy. It can
+ * specify a maxAge and/or a scope.
+ */
+export interface CacheHint {
+  maxAge?: number;
+  scope?: CacheScope;
+}
+
+/**
+ * CachePolicy is a mutable CacheHint with helpful methods for updating its
+ * fields.
+ */
+export interface CachePolicy extends CacheHint {
+  /**
+   * Mutate this CachePolicy by replacing each field defined in `hint`. This can
+   * make the policy more restrictive or less restrictive.
+   */
+  replace(hint: CacheHint): void;
+
+  /**
+   * Mutate this CachePolicy by restricting each field defined in `hint`. This
+   * can only make the policy more restrictive: a previously defined `maxAge`
+   * can only be reduced, and a previously Private scope cannot be made Public.
+   */
+  restrict(hint: CacheHint): void;
+
+  /**
+   * If this policy has a positive `maxAge`, then return a copy of itself as a
+   * `CacheHint` with both fields defined. Otherwise return null.
+   */
+  policyIfCacheable(): Required<CacheHint> | null;
+}
+
+/**
+ * When using Apollo Server with the cache control plugin (on by default), an
+ * object of this kind is available to resolvers on `info.cacheControl`.
+ */
+export interface ResolveInfoCacheControl {
+  cacheHint: CachePolicy;
+  // Shorthand for `cacheHint.replace(hint)`; also for compatibility with
+  // the Apollo Server 2.x API.
+  setCacheHint(hint: CacheHint): void;
+
+  cacheHintFromType(t: GraphQLCompositeType): CacheHint | undefined;
+}
+
+/** When using Apollo Server with the cache control plugin (on by default), the
+ * `info` argument to resolvers can be considered to be of this type. (You can
+ * use this type with the customResolveInfo option to the graphql-code-generator
+ * typescript-resolvers plugin, for example.) */
+export interface GraphQLResolveInfoWithCacheControl extends GraphQLResolveInfo {
+  cacheControl: ResolveInfoCacheControl;
+}
+
+/** Given an `info` resolver argument, returns the cacheControl field if it
+ * exists and appears to be from Apollo Server 3 or newer; returns null
+ * otherwise.*/
+export function maybeCacheControlFromInfo(
+  info: GraphQLResolveInfo,
+): ResolveInfoCacheControl | null {
+  if ((info as any).cacheControl?.cacheHint?.restrict) {
+    return (info as any).cacheControl;
+  }
+  return null;
+}
+
+/** Given an `info` resolver argument, returns the cacheControl field if it
+ * exists and appears to be from Apollo Server 3 or newer; throws
+ * otherwise.*/
+export function cacheControlFromInfo(
+  info: GraphQLResolveInfo,
+): ResolveInfoCacheControl {
+  if (!("cacheControl" in info)) {
+    throw new Error(
+      "The `info` argument does not appear to have a cacheControl field. " +
+        "Check that you are using Apollo Server 3 or newer and that you aren't using " +
+        "ApolloServerPluginCacheControlDisabled.",
+    );
+  }
+  if (!(info as any).cacheControl?.cacheHint?.restrict) {
+    throw new Error(
+      "The `info` argument has a cacheControl field but it does not appear to be from Apollo" +
+        "Server 3 or newer. Check that you are using Apollo Server 3 or newer and that you aren't using " +
+        "ApolloServerPluginCacheControlDisabled.",
+    );
+  }
+  return (info as any).cacheControl;
+}

--- a/packages/cache-control-types/tsconfig.json
+++ b/packages/cache-control-types/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__"]
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,6 +5,7 @@
   "files": [],
   "include": [],
   "references": [
+    { "path": "packages/cache-control-types" },
     { "path": "packages/createHash" },
     { "path": "packages/dropUnusedDefinitions" },
     { "path": "packages/fetcher" },


### PR DESCRIPTION
This package will move to the apollo-server repo once v4.0.0 is
released, but we're putting it here for now so we can do a non-alpha
release.

This will allow us to (among other things) remove the use of
`apollo-server-types` in `@apollo/subgraph`, and remove the `declare
module` in AS4 that would conflict with the AS3 version if both versions
end up installed in a single TS project.

Note that the `CacheAnnotation` type is not moved into this package;
instead, it will become an internal implementation detail of the cache
control plugin.