### PR TITLE
chore(deps): remove stub @types/lru-cache type definition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@types/bunyan": "1.8.8",
         "@types/jest": "28.1.6",
         "@types/lodash.sortby": "4.7.7",
-        "@types/lru-cache": "7.10.10",
         "@types/make-fetch-happen": "10.0.0",
         "@types/node": "12.20.55",
         "@types/node-fetch": "2.6.2",
@@ -1991,16 +1990,6 @@
     "node_modules/@types/long": {
       "version": "4.0.2",
       "license": "MIT"
-    },
-    "node_modules/@types/lru-cache": {
-      "version": "7.10.10",
-      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-7.10.10.tgz",
-      "integrity": "sha512-nEpVRPWW9EBmx2SCfNn3ClYxPL7IktPX12HhIoSc/H5mMjdeW3+YsXIpseLQ2xF35+OcpwKQbEUw5VtqE4PDNA==",
-      "deprecated": "This is a stub types definition. lru-cache provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "*"
-      }
     },
     "node_modules/@types/make-fetch-happen": {
       "version": "10.0.0",
@@ -8664,6 +8653,7 @@
       }
     },
     "packages/server-gateway-interface": {
+      "name": "@apollo/server-gateway-interface",
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
@@ -8676,7 +8666,7 @@
         "node": ">=14.0"
       },
       "peerDependencies": {
-        "graphql": "^16.5.0"
+        "graphql": "14.x || 15.x || 16.x"
       }
     },
     "packages/sortAST": {
@@ -10276,15 +10266,6 @@
     },
     "@types/long": {
       "version": "4.0.2"
-    },
-    "@types/lru-cache": {
-      "version": "7.10.10",
-      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-7.10.10.tgz",
-      "integrity": "sha512-nEpVRPWW9EBmx2SCfNn3ClYxPL7IktPX12HhIoSc/H5mMjdeW3+YsXIpseLQ2xF35+OcpwKQbEUw5VtqE4PDNA==",
-      "dev": true,
-      "requires": {
-        "lru-cache": "*"
-      }
     },
     "@types/make-fetch-happen": {
       "version": "10.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@types/bunyan": "1.8.8",
     "@types/jest": "28.1.6",
     "@types/lodash.sortby": "4.7.7",
-    "@types/lru-cache": "7.10.10",
     "@types/make-fetch-happen": "10.0.0",
     "@types/node": "12.20.55",
     "@types/node-fetch": "2.6.2",


### PR DESCRIPTION
The current version provides its own types; this is an empty package. (Noticed it warning.)