### PR TITLE
@apollo/server-gateway-interface: support Node 12

### DIFF
--- a/.changeset/weak-pots-sneeze.md
+++ b/.changeset/weak-pots-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@apollo/server-gateway-interface": patch
+---
+
+Declare support for Node 12

--- a/packages/server-gateway-interface/package.json
+++ b/packages/server-gateway-interface/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/apollographql/apollo-utils#readme",
   "engines": {
-    "node": ">=14.0"
+    "node": ">=12.0"
   },
   "dependencies": {
     "@apollo/utils.fetcher": "^1.0.0",


### PR DESCRIPTION
We still need to support Node 12 for gateway 0.x.