### PR TITLE
Make tsc capable of building tests, and check before running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,9 @@
     "prettier-check": "prettier --check .",
     "prettier-fix": "prettier --write .",
     "postinstall": "npm run build",
+    "pretest": "tsc --build tsconfig.json",
     "test": "jest --verbose",
-    "test:ci": "jest --coverage --ci --maxWorkers=2 --reporters=default --reporters=jest-junit",
+    "test:ci": "npm test -- --coverage --ci --maxWorkers=2 --reporters=default --reporters=jest-junit",
     "watch": "npm run build -- --watch",
     "changeset-publish": "changeset publish",
     "install-with-npm-8.5": "npm i -g npm@^8.5.0 && npm i"

--- a/tsconfig.test.base.json
+++ b/tsconfig.test.base.json
@@ -2,6 +2,10 @@
   "extends": "./tsconfig.base",
   "compilerOptions": {
     "noEmit": true,
-    "types": ["node", "jest"]
+    "types": ["node", "jest"],
+    // In tests, we use undici, whose .d.ts files assume @types/node v14
+    // or later (to use Blob from buffer, etc). For now we just won't
+    // type-check our test node_modules .d.ts files.
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
For whatever reason, Jest was happy with this (perhaps it implicitly
builds with skipLibCheck?) but you couldn't use `tsc`.