### PR TITLE
server-gateway-interface: work with AS2 too

### DIFF
--- a/.changeset/tough-tigers-roll.md
+++ b/.changeset/tough-tigers-roll.md
@@ -1,0 +1,5 @@
+---
+"@apollo/server-gateway-interface": patch
+---
+
+Make the interface more compatible with Apollo Server 2

--- a/packages/server-gateway-interface/src/index.ts
+++ b/packages/server-gateway-interface/src/index.ts
@@ -68,7 +68,10 @@ export interface GatewayGraphQLRequestContext<TContext = Record<string, any>> {
   readonly errors?: ReadonlyArray<GraphQLError>;
   readonly metrics: GatewayGraphQLRequestMetrics;
   debug?: boolean;
-  readonly overallCachePolicy: GatewayCachePolicy;
+  // In AS3 and AS4, this field is always set and is a GatewayCachePolicy, but
+  // in AS2 it is not always set and is only a GatewayCacheHint. To keep Gateway
+  // compatible with AS2, we allow either case here.
+  readonly overallCachePolicy?: GatewayCachePolicy | GatewayCacheHint;
 }
 
 export interface GatewayGraphQLRequest {


### PR DESCRIPTION
The consumer of this in `@apollo/gateway` is already doing some weird
stuff with `Omit` around this field, so just explicitly allow the AS2
case.

See https://github.com/apollographql/federation/issues/2077