### PR TITLE
Add ESM support for types-only packages

### DIFF
--- a/.changeset/silent-rocks-punch.md
+++ b/.changeset/silent-rocks-punch.md
@@ -1,0 +1,7 @@
+---
+"@apollo/utils.fetcher": patch
+"@apollo/utils.logger": patch
+"@apollo/utils.withrequired": patch
+---
+
+Support ESM for types-only packages

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -2,6 +2,7 @@
   "name": "@apollo/utils.fetcher",
   "version": "1.1.0",
   "description": "Minimal web-style fetch TypeScript typings",
+  "main": "",
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -2,6 +2,7 @@
   "name": "@apollo/utils.logger",
   "version": "1.0.0",
   "description": "Generic logger interface",
+  "main": "",
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",

--- a/packages/withRequired/package.json
+++ b/packages/withRequired/package.json
@@ -2,6 +2,7 @@
   "name": "@apollo/utils.withrequired",
   "version": "1.0.0",
   "description": "TypeScript utility type WithRequired",
+  "main": "",
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The `"main": ""` approach is employed by DefinitelyTyped packages as a means to support types-only packages being importable in both CJS and ESM contexts. (as seen here, for example: https://unpkg.com/@types/make-fetch-happen@10.0.0/package.json)

Fixes https://github.com/apollographql/apollo-utils/issues/207