### PR TITLE
Drop support for Node 12

### DIFF
--- a/.changeset/curly-plants-serve.md
+++ b/.changeset/curly-plants-serve.md
@@ -1,0 +1,19 @@
+---
+"@apollo/utils.createhash": major
+"@apollo/utils.dropunuseddefinitions": major
+"@apollo/utils.fetcher": major
+"@apollo/utils.isnodelike": major
+"@apollo/utils.jest-graphql-ast-serializer": major
+"@apollo/utils.keyvaluecache": major
+"@apollo/utils.keyvadapter": major
+"@apollo/utils.logger": major
+"@apollo/utils.operationregistrysignature": major
+"@apollo/utils.printwithreducedwhitespace": major
+"@apollo/utils.removealiases": major
+"@apollo/utils.sortast": major
+"@apollo/utils.stripsensitiveliterals": major
+"@apollo/utils.usagereporting": major
+"@apollo/utils.withrequired": major
+---
+
+Drop support for Node.js v12, all packages now require >=14

--- a/.changeset/curly-plants-serve.md
+++ b/.changeset/curly-plants-serve.md
@@ -16,4 +16,4 @@
 "@apollo/utils.withrequired": major
 ---
 
-Drop support for Node.js v12, all packages now require >=14
+Drop support for Node.js v12; all packages now require Node.js version >=14.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,6 @@ workflows:
           matrix:
             parameters:
               node-version:
-                - "12"
                 - "14"
                 - "16"
                 - "18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,8 +39,8 @@
         "winston-transport": "4.5.0"
       },
       "engines": {
-        "node": ">=12.13.0",
-        "npm": ">=7 <9"
+        "node": ">=14",
+        "npm": ">=8"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -8505,7 +8505,7 @@
         "sha.js": "^2.4.11"
       },
       "engines": {
-        "node": ">=12.13.0"
+        "node": ">=14"
       }
     },
     "packages/dropUnusedDefinitions": {
@@ -8513,7 +8513,7 @@
       "version": "1.1.0",
       "license": "MIT",
       "engines": {
-        "node": ">=12.13.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "graphql": "14.x || 15.x || 16.x"
@@ -8522,14 +8522,17 @@
     "packages/fetcher": {
       "name": "@apollo/utils.fetcher",
       "version": "1.1.1",
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "packages/isNodeLike": {
       "name": "@apollo/utils.isnodelike",
       "version": "1.1.0",
       "license": "MIT",
       "engines": {
-        "node": ">=12.13.0"
+        "node": ">=14"
       }
     },
     "packages/jestGraphQLASTSerializer": {
@@ -8537,7 +8540,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "engines": {
-        "node": ">=12.13.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "graphql": "14.x || 15.x || 16.x"
@@ -8551,6 +8554,9 @@
         "@apollo/utils.keyvaluecache": "^1.0.1",
         "dataloader": "^2.1.0",
         "keyv": "^4.4.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "packages/keyvAdapter/node_modules/dataloader": {
@@ -8565,6 +8571,9 @@
       "dependencies": {
         "@apollo/utils.logger": "^1.0.0",
         "lru-cache": "^7.10.1 - 7.13.1"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "packages/keyValueCache/node_modules/lru-cache": {
@@ -8578,7 +8587,10 @@
     "packages/logger": {
       "name": "@apollo/utils.logger",
       "version": "1.0.1",
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "packages/operationRegistrySignature": {
       "name": "@apollo/utils.operationregistrysignature",
@@ -8591,7 +8603,7 @@
         "@apollo/utils.stripsensitiveliterals": "^1.1.0"
       },
       "engines": {
-        "node": ">=12.13.0"
+        "node": ">=14"
       }
     },
     "packages/printWithReducedWhitespace": {
@@ -8599,7 +8611,7 @@
       "version": "1.1.0",
       "license": "MIT",
       "engines": {
-        "node": ">=12.13.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "graphql": "14.x || 15.x || 16.x"
@@ -8610,7 +8622,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "engines": {
-        "node": ">=12.13.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "graphql": "14.x || 15.x || 16.x"
@@ -8624,7 +8636,7 @@
         "lodash.sortby": "^4.7.0"
       },
       "engines": {
-        "node": ">=12.13.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "graphql": "14.x || 15.x || 16.x"
@@ -8635,7 +8647,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "engines": {
-        "node": ">=12.13.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "graphql": "14.x || 15.x || 16.x"
@@ -8654,7 +8666,7 @@
         "apollo-reporting-protobuf": "^3.3.1"
       },
       "engines": {
-        "node": ">=12.13.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "graphql": "14.x || 15.x || 16.x"
@@ -8663,7 +8675,10 @@
     "packages/withRequired": {
       "name": "@apollo/utils.withrequired",
       "version": "1.0.1",
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     }
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "engines": {
     "node": ">=14",
-    "npm": ">7 <=9"
+    "npm": ">=8"
   },
   "scripts": {
     "clean": "git clean -dfqX",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "author": "Apollo <packages@apollographql.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=12.13.0",
-    "npm": ">=7 <9"
+    "node": ">=14",
+    "npm": ">7 <=9"
   },
   "scripts": {
     "clean": "git clean -dfqX",

--- a/packages/createHash/package.json
+++ b/packages/createHash/package.json
@@ -18,7 +18,7 @@
   "author": "Apollo <packages@apollographql.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=12.13.0"
+    "node": ">=14"
   },
   "dependencies": {
     "@apollo/utils.isnodelike": "^1.1.0",

--- a/packages/dropUnusedDefinitions/package.json
+++ b/packages/dropUnusedDefinitions/package.json
@@ -18,7 +18,7 @@
   "author": "Apollo <packages@apollographql.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=12.13.0"
+    "node": ">=14"
   },
   "peerDependencies": {
     "graphql": "14.x || 15.x || 16.x"

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -16,5 +16,8 @@
     "node"
   ],
   "author": "Apollo <packages@apollographql.com>",
-  "license": "MIT"
+  "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  }
 }

--- a/packages/isNodeLike/package.json
+++ b/packages/isNodeLike/package.json
@@ -18,6 +18,6 @@
   "author": "Apollo <packages@apollographql.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=12.13.0"
+    "node": ">=14"
   }
 }

--- a/packages/jestGraphQLASTSerializer/package.json
+++ b/packages/jestGraphQLASTSerializer/package.json
@@ -19,7 +19,7 @@
   "author": "Apollo <packages@apollographql.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=12.13.0"
+    "node": ">=14"
   },
   "peerDependencies": {
     "graphql": "14.x || 15.x || 16.x"

--- a/packages/keyValueCache/package.json
+++ b/packages/keyValueCache/package.json
@@ -17,6 +17,9 @@
   ],
   "author": "Apollo <packages@apollographql.com>",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "dependencies": {
     "@apollo/utils.logger": "^1.0.0",
     "lru-cache": "^7.10.1 - 7.13.1"

--- a/packages/keyvAdapter/package.json
+++ b/packages/keyvAdapter/package.json
@@ -17,6 +17,9 @@
   ],
   "author": "Apollo <packages@apollographql.com>",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "dependencies": {
     "@apollo/utils.keyvaluecache": "^1.0.1",
     "dataloader": "^2.1.0",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -16,5 +16,8 @@
     "node"
   ],
   "author": "Apollo <packages@apollographql.com>",
-  "license": "MIT"
+  "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  }
 }

--- a/packages/operationRegistrySignature/package.json
+++ b/packages/operationRegistrySignature/package.json
@@ -18,7 +18,7 @@
   "author": "Apollo <packages@apollographql.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=12.13.0"
+    "node": ">=14"
   },
   "dependencies": {
     "@apollo/utils.dropunuseddefinitions": "^1.1.0",

--- a/packages/printWithReducedWhitespace/package.json
+++ b/packages/printWithReducedWhitespace/package.json
@@ -18,7 +18,7 @@
   "author": "Apollo <packages@apollographql.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=12.13.0"
+    "node": ">=14"
   },
   "peerDependencies": {
     "graphql": "14.x || 15.x || 16.x"

--- a/packages/removeAliases/package.json
+++ b/packages/removeAliases/package.json
@@ -18,7 +18,7 @@
   "author": "Apollo <packages@apollographql.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=12.13.0"
+    "node": ">=14"
   },
   "peerDependencies": {
     "graphql": "14.x || 15.x || 16.x"

--- a/packages/sortAST/package.json
+++ b/packages/sortAST/package.json
@@ -18,7 +18,7 @@
   "author": "Apollo <packages@apollographql.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=12.13.0"
+    "node": ">=14"
   },
   "dependencies": {
     "lodash.sortby": "^4.7.0"

--- a/packages/stripSensitiveLiterals/package.json
+++ b/packages/stripSensitiveLiterals/package.json
@@ -18,7 +18,7 @@
   "author": "Apollo <packages@apollographql.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=12.13.0"
+    "node": ">=14"
   },
   "peerDependencies": {
     "graphql": "14.x || 15.x || 16.x"

--- a/packages/usageReporting/package.json
+++ b/packages/usageReporting/package.json
@@ -18,7 +18,7 @@
   "author": "Apollo <packages@apollographql.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=12.13.0"
+    "node": ">=14"
   },
   "dependencies": {
     "@apollo/utils.dropunuseddefinitions": "^1.1.0",

--- a/packages/withRequired/package.json
+++ b/packages/withRequired/package.json
@@ -16,5 +16,8 @@
     "node"
   ],
   "author": "Apollo <packages@apollographql.com>",
-  "license": "MIT"
+  "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  }
 }


### PR DESCRIPTION
Node v12 is now EOL, we should drop support for it.

Testing against Node v12 is currently blocking some major upgrades:
https://github.com/apollographql/apollo-utils/pull/193
https://github.com/apollographql/apollo-utils/pull/206