### PR TITLE
fix: migrate from apollo-reporting-protobuf to @apollo/usage-reporting-protobuf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,10 +54,19 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@apollo/protobufjs": {
-      "version": "1.2.2",
+    "node_modules/@apollo/usage-reporting-protobuf": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@apollo/usage-reporting-protobuf/-/usage-reporting-protobuf-4.0.2.tgz",
+      "integrity": "sha512-GfE8aDqi/lAFut95pjH9IRvH0zGsQ5G/2lYL0ZLZfML7ArX+A4UVHFANQcPCcUYGE6bI6OPhLekg4Vsjf6B1cw==",
+      "dependencies": {
+        "@apollo/protobufjs": "1.2.7"
+      }
+    },
+    "node_modules/@apollo/usage-reporting-protobuf/node_modules/@apollo/protobufjs": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.7.tgz",
+      "integrity": "sha512-Lahx5zntHPZia35myYDBRuF58tlwPskwHc5CWBZC/4bMKB6siTBWwtMrkqXcsNwQiFSzSx5hKdRPUmemrEp3Gg==",
       "hasInstallScript": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -70,17 +79,12 @@
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
         "@types/long": "^4.0.0",
-        "@types/node": "^10.1.0",
         "long": "^4.0.0"
       },
       "bin": {
         "apollo-pbjs": "bin/pbjs",
         "apollo-pbts": "bin/pbts"
       }
-    },
-    "node_modules/@apollo/protobufjs/node_modules/@types/node": {
-      "version": "10.17.60",
-      "license": "MIT"
     },
     "node_modules/@apollo/utils.createhash": {
       "resolved": "packages/createHash",
@@ -2115,13 +2119,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/apollo-reporting-protobuf": {
-      "version": "3.3.1",
-      "license": "MIT",
-      "dependencies": {
-        "@apollo/protobufjs": "1.2.2"
       }
     },
     "node_modules/arg": {
@@ -8647,12 +8644,12 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@apollo/usage-reporting-protobuf": "^4.0.0",
         "@apollo/utils.dropunuseddefinitions": "^1.1.0",
         "@apollo/utils.printwithreducedwhitespace": "^1.1.0",
         "@apollo/utils.removealiases": "1.0.0",
         "@apollo/utils.sortast": "^1.1.0",
-        "@apollo/utils.stripsensitiveliterals": "^1.2.0",
-        "apollo-reporting-protobuf": "^3.3.1"
+        "@apollo/utils.stripsensitiveliterals": "^1.2.0"
       },
       "engines": {
         "node": ">=12.13.0"
@@ -8675,26 +8672,32 @@
         "@jridgewell/trace-mapping": "^0.3.0"
       }
     },
-    "@apollo/protobufjs": {
-      "version": "1.2.2",
+    "@apollo/usage-reporting-protobuf": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@apollo/usage-reporting-protobuf/-/usage-reporting-protobuf-4.0.2.tgz",
+      "integrity": "sha512-GfE8aDqi/lAFut95pjH9IRvH0zGsQ5G/2lYL0ZLZfML7ArX+A4UVHFANQcPCcUYGE6bI6OPhLekg4Vsjf6B1cw==",
       "requires": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.0",
-        "@types/node": "^10.1.0",
-        "long": "^4.0.0"
+        "@apollo/protobufjs": "1.2.7"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "10.17.60"
+        "@apollo/protobufjs": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.7.tgz",
+          "integrity": "sha512-Lahx5zntHPZia35myYDBRuF58tlwPskwHc5CWBZC/4bMKB6siTBWwtMrkqXcsNwQiFSzSx5hKdRPUmemrEp3Gg==",
+          "requires": {
+            "@protobufjs/aspromise": "^1.1.2",
+            "@protobufjs/base64": "^1.1.2",
+            "@protobufjs/codegen": "^2.0.4",
+            "@protobufjs/eventemitter": "^1.1.0",
+            "@protobufjs/fetch": "^1.1.0",
+            "@protobufjs/float": "^1.0.2",
+            "@protobufjs/inquire": "^1.1.0",
+            "@protobufjs/path": "^1.1.2",
+            "@protobufjs/pool": "^1.1.0",
+            "@protobufjs/utf8": "^1.1.0",
+            "@types/long": "^4.0.0",
+            "long": "^4.0.0"
+          }
         }
       }
     },
@@ -8781,12 +8784,12 @@
     "@apollo/utils.usagereporting": {
       "version": "file:packages/usageReporting",
       "requires": {
+        "@apollo/usage-reporting-protobuf": "^4.0.0",
         "@apollo/utils.dropunuseddefinitions": "^1.1.0",
         "@apollo/utils.printwithreducedwhitespace": "^1.1.0",
         "@apollo/utils.removealiases": "1.0.0",
         "@apollo/utils.sortast": "^1.1.0",
-        "@apollo/utils.stripsensitiveliterals": "^1.2.0",
-        "apollo-reporting-protobuf": "^3.3.1"
+        "@apollo/utils.stripsensitiveliterals": "^1.2.0"
       }
     },
     "@apollo/utils.withrequired": {
@@ -10300,12 +10303,6 @@
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
-      }
-    },
-    "apollo-reporting-protobuf": {
-      "version": "3.3.1",
-      "requires": {
-        "@apollo/protobufjs": "1.2.2"
       }
     },
     "arg": {

--- a/packages/usageReporting/package.json
+++ b/packages/usageReporting/package.json
@@ -21,12 +21,12 @@
     "node": ">=12.13.0"
   },
   "dependencies": {
+    "@apollo/usage-reporting-protobuf": "^4.0.0",
     "@apollo/utils.dropunuseddefinitions": "^1.1.0",
     "@apollo/utils.stripsensitiveliterals": "^1.2.0",
     "@apollo/utils.printwithreducedwhitespace": "^1.1.0",
     "@apollo/utils.removealiases": "1.0.0",
-    "@apollo/utils.sortast": "^1.1.0",
-    "apollo-reporting-protobuf": "^3.3.1"
+    "@apollo/utils.sortast": "^1.1.0"
   },
   "peerDependencies": {
     "graphql": "14.x || 15.x || 16.x"

--- a/packages/usageReporting/src/calculateReferencedFieldsByType.ts
+++ b/packages/usageReporting/src/calculateReferencedFieldsByType.ts
@@ -7,7 +7,7 @@ import {
   visit,
   visitWithTypeInfo,
 } from "graphql";
-import { ReferencedFieldsForType } from "apollo-reporting-protobuf";
+import { ReferencedFieldsForType } from "@apollo/usage-reporting-protobuf";
 
 export interface OperationDerivedData {
   signature: string;


### PR DESCRIPTION
Noticed we're pulling in two versions of `@apollo/protobufjs`.

<img width="419" alt="image" src="https://user-images.githubusercontent.com/1404810/201677106-5207a8fe-64c5-4c17-bc35-c758b3fda885.png">