### PR TITLE
Fix specified `lru-cache` version range and update `@types/node` version

### DIFF
--- a/.changeset/plenty-cats-return.md
+++ b/.changeset/plenty-cats-return.md
@@ -2,4 +2,5 @@
 "@apollo/utils.keyvaluecache": patch
 ---
 
-Fix the version range specified for `lru-cache` which was previously invalid
+Fix the version range specified for `lru-cache` which was previously invalid. Unpin the range now that we've dropped support for node@12
+and this was originally a `@types/node@12` issue.

--- a/.changeset/plenty-cats-return.md
+++ b/.changeset/plenty-cats-return.md
@@ -1,0 +1,5 @@
+---
+"@apollo/utils.keyvaluecache": patch
+---
+
+Fix the version range specified for `lru-cache` which was previously invalid

--- a/package-lock.json
+++ b/package-lock.json
@@ -8501,16 +8501,16 @@
       "license": "MIT",
       "dependencies": {
         "@apollo/utils.logger": "^2.0.0",
-        "lru-cache": "7.10.1 - 7.13.1"
+        "lru-cache": "^7.14.1"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "packages/keyValueCache/node_modules/lru-cache": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.13.1.tgz",
-      "integrity": "sha512-CHqbAq7NFlW3RSnoWXLJBxCWaZVBrfa9UEHId2M3AW8iEBurbqduNexEUCGc3SHc6iCYXNJCDi903LajSVAEPQ==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
+      "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==",
       "engines": {
         "node": ">=12"
       }
@@ -8689,13 +8689,13 @@
       "version": "file:packages/keyValueCache",
       "requires": {
         "@apollo/utils.logger": "^2.0.0",
-        "lru-cache": "7.10.1 - 7.13.1"
+        "lru-cache": "^7.14.1"
       },
       "dependencies": {
         "lru-cache": {
-          "version": "7.13.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.13.1.tgz",
-          "integrity": "sha512-CHqbAq7NFlW3RSnoWXLJBxCWaZVBrfa9UEHId2M3AW8iEBurbqduNexEUCGc3SHc6iCYXNJCDi903LajSVAEPQ=="
+          "version": "7.14.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
+          "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/jest": "29.2.3",
         "@types/lodash.sortby": "4.7.7",
         "@types/make-fetch-happen": "10.0.0",
-        "@types/node": "12.20.55",
+        "@types/node": "14.18.33",
         "@types/node-fetch": "2.6.2",
         "bunyan": "1.8.15",
         "graphql": "16.6.0",
@@ -1618,6 +1618,12 @@
         "fs-extra": "^8.1.0"
       }
     },
+    "node_modules/@manypkg/find-root/node_modules/@types/node": {
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "dev": true
+    },
     "node_modules/@manypkg/find-root/node_modules/fs-extra": {
       "version": "8.1.0",
       "dev": true,
@@ -1951,9 +1957,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "12.20.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "version": "14.18.33",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.33.tgz",
+      "integrity": "sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg==",
       "dev": true
     },
     "node_modules/@types/node-fetch": {
@@ -9870,6 +9876,12 @@
         "fs-extra": "^8.1.0"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "12.20.55",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+          "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+          "dev": true
+        },
         "fs-extra": {
           "version": "8.1.0",
           "dev": true,
@@ -10149,9 +10161,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.20.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "version": "14.18.33",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.33.tgz",
+      "integrity": "sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg==",
       "dev": true
     },
     "@types/node-fetch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8501,7 +8501,7 @@
       "license": "MIT",
       "dependencies": {
         "@apollo/utils.logger": "^2.0.0",
-        "lru-cache": "^7.10.1 - 7.13.1"
+        "lru-cache": "7.10.1 - 7.13.1"
       },
       "engines": {
         "node": ">=14"
@@ -8689,7 +8689,7 @@
       "version": "file:packages/keyValueCache",
       "requires": {
         "@apollo/utils.logger": "^2.0.0",
-        "lru-cache": "^7.10.1 - 7.13.1"
+        "lru-cache": "7.10.1 - 7.13.1"
       },
       "dependencies": {
         "lru-cache": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/jest": "29.2.3",
     "@types/lodash.sortby": "4.7.7",
     "@types/make-fetch-happen": "10.0.0",
-    "@types/node": "12.20.55",
+    "@types/node": "14.18.33",
     "@types/node-fetch": "2.6.2",
     "bunyan": "1.8.15",
     "graphql": "16.6.0",

--- a/packages/keyValueCache/package.json
+++ b/packages/keyValueCache/package.json
@@ -22,6 +22,6 @@
   },
   "dependencies": {
     "@apollo/utils.logger": "^2.0.0",
-    "lru-cache": "^7.10.1 - 7.13.1"
+    "lru-cache": "7.10.1 - 7.13.1"
   }
 }

--- a/packages/keyValueCache/package.json
+++ b/packages/keyValueCache/package.json
@@ -22,6 +22,6 @@
   },
   "dependencies": {
     "@apollo/utils.logger": "^2.0.0",
-    "lru-cache": "7.10.1 - 7.13.1"
+    "lru-cache": "^7.14.1"
   }
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -33,11 +33,5 @@
       "matchPackageNames": ["graphql"],
       "automerge": false,
     },
-    // pin lru-cache until AbortSignal typings issue is addressed
-    // https://github.com/isaacs/node-lru-cache/pull/247#issuecomment-1204481394
-    {
-      "matchPackageNames": ["lru-cache"],
-      "allowedVersions": "7.10.1 - 7.13.1"
-    },
   ],
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -18,8 +18,8 @@
       "matchUpdateTypes": ["patch", "minor"],
       "groupSlug": "all-minor-patch",
     },
-    // We need to support Node v12, so we don't allow ourselves to use type definitions
-    // that would let us write v14-specific code.
+    // We need to support Node v14, so we don't allow ourselves to use type definitions
+    // that would let us write >v14-specific code.
     {
       "matchPackageNames": ["@types/node"],
       "allowedVersions": "14.x"

--- a/renovate.json5
+++ b/renovate.json5
@@ -22,7 +22,7 @@
     // that would let us write v14-specific code.
     {
       "matchPackageNames": ["@types/node"],
-      "allowedVersions": "12.x"
+      "allowedVersions": "14.x"
     },
     // node-fetch v3 only ships as ESM. So let's stay on v2.
     {

--- a/renovate.json5
+++ b/renovate.json5
@@ -37,7 +37,7 @@
     // https://github.com/isaacs/node-lru-cache/pull/247#issuecomment-1204481394
     {
       "matchPackageNames": ["lru-cache"],
-      "allowedVersions": "^7.10.1 - 7.13.1"
+      "allowedVersions": "7.10.1 - 7.13.1"
     },
   ],
 }


### PR DESCRIPTION
Introduced as a consequence of the renovate config I created:
cab3444fa06e7ecc0e1918807d9578869407d65b (from #169)

Issue raised by @SimenB here:
https://github.com/apollographql/apollo-utils/pull/169#discussion_r1030190816

This PR also updates the `@types/node` version to 14, which should've been done as part of dropping node 12 support and happens to be a requirement for this PR.