### PR TITLE
keyvaluecache: add PrefixesAreUnnecessaryForIsolationCache

### DIFF
--- a/.changeset/red-bags-pump.md
+++ b/.changeset/red-bags-pump.md
@@ -2,4 +2,4 @@
 "@apollo/utils.keyvaluecache": minor
 ---
 
-New class `PrefixesAreUnnecessaryForIsolationCache` and function `prefixesAreUnnecessaryForIsolation` allows you to opt a particular cache out of the prefixing done by a `PrefixingKeyValueCache`.
+New static methods `PrefixingKeyValueCache.cacheDangerouslyDoesNotNeedPrefixesForIsolation` and `PrefixingKeyValueCache.prefixesAreUnnecessaryForIsolation` allows you to opt a particular cache out of the prefixing done by a `PrefixingKeyValueCache`.

--- a/.changeset/red-bags-pump.md
+++ b/.changeset/red-bags-pump.md
@@ -1,0 +1,5 @@
+---
+"@apollo/utils.keyvaluecache": minor
+---
+
+New class `PrefixesAreUnnecessaryForIsolationCache` and function `prefixesAreUnnecessaryForIsolation` allows you to opt a particular cache out of the prefixing done by a `PrefixingKeyValueCache`.

--- a/packages/keyValueCache/README.md
+++ b/packages/keyValueCache/README.md
@@ -32,7 +32,7 @@ const prefixedCache = new PrefixingKeyValueCache(cache, "apollo:");
 
 One reason to use this is if a single piece of software wants to use a cache for multiple features. For example, you can pass a `KeyValueCache` as the `cache` option to `@apollo/server`'s `ApolloServer` class; it provides this cache to plugins and other features as a default cache to use (if the user does not provide the specific plugin its own cache). Each feature uses `PrefixingKeyValueCache` with a different prefix to prevent different features from stomping on each others' data.
 
-However, if you are configuring one of those features explicitly, you may _not_ want this prefix to be added. In that case, you can wrap your cache in a `PrefixesAreUnnecessaryForIsolationCache`. The only difference between this cache and the cache that it wraps is that when it is passed directly to a `PrefixingKeyValueCache`, no prefix is applied.
+However, if you are configuring one of those features explicitly, you may _not_ want this prefix to be added. In that case, you can wrap your cache in a cache returned by `PrefixingKeyValueCache.cacheDangerouslyDoesNotNeedPrefixesForIsolation`. The only difference between this cache and the cache that it wraps is that when it is passed directly to a `PrefixingKeyValueCache`, no prefix is applied.
 
 That is, let's say you are using a class that is implemented like this:
 
@@ -45,9 +45,9 @@ class SomePlugin {
 }
 ```
 
-If you set up your plugin as `new SomePlugin({ cache: myRedisCache })` then the plugin will add `some:` to all keys when interacting with your cache, but if you set it up as `new SomePlugin({ cache: new PrefixesAreUnnecessaryForIsolationCache(myRedisCache) })`, then the plugin will not apply its prefix. You should only do this if you feel confident that this feature's use of this cache will not overlap with another feature: perhaps this is the only feature you have configured to use this cache, or perhaps the feature provides suitable control over cache keys that you can ensure isolation without needing the plugin's prefix.
+If you set up your plugin as `new SomePlugin({ cache: myRedisCache })` then the plugin will add `some:` to all keys when interacting with your cache, but if you set it up as `new SomePlugin({ cache: PrefixingKeyValueCache.cacheDangerouslyDoesNotNeedPrefixesForIsolation(myRedisCache) })`, then the plugin will not apply its prefix. You should only do this if you feel confident that this feature's use of this cache will not overlap with another feature: perhaps this is the only feature you have configured to use this cache, or perhaps the feature provides suitable control over cache keys that you can ensure isolation without needing the plugin's prefix.
 
-Software like `ApolloServer` that passes a single `KeyValueCache` to several features should throw if a `PrefixesAreUnnecessaryForIsolationCache` is provided to it; it can check this condition with the `prefixesAreUnnecessaryForIsolation` (which is safer than an `instanceof` check in case there are multiple copies of `@apollo/utils.keyvaluecache` installed).
+Software like `ApolloServer` that passes a single `KeyValueCache` to several features should throw if a `PrefixesAreUnnecessaryForIsolationCache` is provided to it; it can check this condition with the static `PrefixingKeyValueCache.prefixesAreUnnecessaryForIsolation` method (which is safer than an `instanceof` check in case there are multiple copies of `@apollo/utils.keyvaluecache` installed).
 
 # ErrorsAreMissesCache
 

--- a/packages/keyValueCache/README.md
+++ b/packages/keyValueCache/README.md
@@ -30,6 +30,25 @@ const cache = new InMemoryLRUCache();
 const prefixedCache = new PrefixingKeyValueCache(cache, "apollo:");
 ```
 
+One reason to use this is if a single piece of software wants to use a cache for multiple features. For example, you can pass a `KeyValueCache` as the `cache` option to `@apollo/server`'s `ApolloServer` class; it provides this cache to plugins and other features as a default cache to use (if the user does not provide the specific plugin its own cache). Each feature uses `PrefixingKeyValueCache` with a different prefix to prevent different features from stomping on each others' data.
+
+However, if you are configuring one of those features explicitly, you may _not_ want this prefix to be added. In that case, you can wrap your cache in a `PrefixesAreUnnecessaryForIsolationCache`. The only difference between this cache and the cache that it wraps is that when it is passed directly to a `PrefixingKeyValueCache`, no prefix is applied.
+
+That is, let's say you are using a class that is implemented like this:
+
+```ts
+class SomePlugin {
+  private cache: KeyValueCache;
+  constructor(cache: KeyValueCache) {
+    this.cache = new PrefixingKeyValueCache(cache, "some:");
+  }
+}
+```
+
+If you set up your plugin as `new SomePlugin({ cache: myRedisCache })` then the plugin will add `some:` to all keys when interacting with your cache, but if you set it up as `new SomePlugin({ cache: new PrefixesAreUnnecessaryForIsolationCache(myRedisCache) })`, then the plugin will not apply its prefix. You should only do this if you feel confident that this feature's use of this cache will not overlap with another feature: perhaps this is the only feature you have configured to use this cache, or perhaps the feature provides suitable control over cache keys that you can ensure isolation without needing the plugin's prefix.
+
+Software like `ApolloServer` that passes a single `KeyValueCache` to several features should throw if a `PrefixesAreUnnecessaryForIsolationCache` is provided to it; it can check this condition with the `prefixesAreUnnecessaryForIsolation` (which is safer than an `instanceof` check in case there are multiple copies of `@apollo/utils.keyvaluecache` installed).
+
 # ErrorsAreMissesCache
 
 This class wraps a `KeyValueCache` in order to provide error tolerance for caches which connect via a client like Redis. In the event that there's an _error_, this wrapper will treat it as a cache miss (and log the error instead, if a `logger` is provided).

--- a/packages/keyValueCache/src/__tests__/PrefixingKeyValueCache.test.ts
+++ b/packages/keyValueCache/src/__tests__/PrefixingKeyValueCache.test.ts
@@ -41,9 +41,8 @@ describe("PrefixingKeyValueCache", () => {
         prefixesAreUnnecessaryForIsolationCache,
       ),
     ).toBe(true);
-    // This only detects caches where the "outermost" cache has the "prefixes unnecessary" label.
     expect(
       PrefixingKeyValueCache.prefixesAreUnnecessaryForIsolation(prefixing),
-    ).toBe(false);
+    ).toBe(true);
   });
 });

--- a/packages/keyValueCache/src/__tests__/PrefixingKeyValueCache.test.ts
+++ b/packages/keyValueCache/src/__tests__/PrefixingKeyValueCache.test.ts
@@ -1,9 +1,5 @@
 import { InMemoryLRUCache } from "..";
-import {
-  prefixesAreUnnecessaryForIsolation,
-  PrefixesAreUnnecessaryForIsolationCache,
-  PrefixingKeyValueCache,
-} from "../PrefixingKeyValueCache";
+import { PrefixingKeyValueCache } from "../PrefixingKeyValueCache";
 
 describe("PrefixingKeyValueCache", () => {
   it("prefixes", async () => {
@@ -18,7 +14,9 @@ describe("PrefixingKeyValueCache", () => {
   it("PrefixesAreUnnecessaryForIsolationCache", async () => {
     const inner = new InMemoryLRUCache();
     const prefixesAreUnnecessaryForIsolationCache =
-      new PrefixesAreUnnecessaryForIsolationCache(inner);
+      PrefixingKeyValueCache.cacheDangerouslyDoesNotNeedPrefixesForIsolation(
+        inner,
+      );
     const prefixing = new PrefixingKeyValueCache(
       prefixesAreUnnecessaryForIsolationCache,
       "prefix:",
@@ -35,13 +33,17 @@ describe("PrefixingKeyValueCache", () => {
       expect(inner.keys().length).toBe(0);
     }
 
-    expect(prefixesAreUnnecessaryForIsolation(inner)).toBe(false);
     expect(
-      prefixesAreUnnecessaryForIsolation(
+      PrefixingKeyValueCache.prefixesAreUnnecessaryForIsolation(inner),
+    ).toBe(false);
+    expect(
+      PrefixingKeyValueCache.prefixesAreUnnecessaryForIsolation(
         prefixesAreUnnecessaryForIsolationCache,
       ),
     ).toBe(true);
     // This only detects caches where the "outermost" cache has the "prefixes unnecessary" label.
-    expect(prefixesAreUnnecessaryForIsolation(prefixing)).toBe(false);
+    expect(
+      PrefixingKeyValueCache.prefixesAreUnnecessaryForIsolation(prefixing),
+    ).toBe(false);
   });
 });

--- a/packages/keyValueCache/src/__tests__/PrefixingKeyValueCache.test.ts
+++ b/packages/keyValueCache/src/__tests__/PrefixingKeyValueCache.test.ts
@@ -1,5 +1,9 @@
 import { InMemoryLRUCache } from "..";
-import { PrefixingKeyValueCache } from "../PrefixingKeyValueCache";
+import {
+  prefixesAreUnnecessaryForIsolation,
+  PrefixesAreUnnecessaryForIsolationCache,
+  PrefixingKeyValueCache,
+} from "../PrefixingKeyValueCache";
 
 describe("PrefixingKeyValueCache", () => {
   it("prefixes", async () => {
@@ -10,5 +14,34 @@ describe("PrefixingKeyValueCache", () => {
     expect(await inner.get("prefix:foo")).toBe("bar");
     await prefixing.delete("foo");
     expect(await prefixing.get("foo")).toBe(undefined);
+  });
+  it("PrefixesAreUnnecessaryForIsolationCache", async () => {
+    const inner = new InMemoryLRUCache();
+    const prefixesAreUnnecessaryForIsolationCache =
+      new PrefixesAreUnnecessaryForIsolationCache(inner);
+    const prefixing = new PrefixingKeyValueCache(
+      prefixesAreUnnecessaryForIsolationCache,
+      "prefix:",
+    );
+
+    for (const cache of [prefixesAreUnnecessaryForIsolationCache, prefixing]) {
+      await cache.set("x", "a");
+      expect(await cache.get("x")).toBe("a");
+      expect(inner.keys().length).toBe(1);
+      // The prefix is not applied!
+      expect(await inner.get("x")).toBe("a");
+      await cache.delete("x");
+      expect(await cache.get("x")).toBe(undefined);
+      expect(inner.keys().length).toBe(0);
+    }
+
+    expect(prefixesAreUnnecessaryForIsolation(inner)).toBe(false);
+    expect(
+      prefixesAreUnnecessaryForIsolation(
+        prefixesAreUnnecessaryForIsolationCache,
+      ),
+    ).toBe(true);
+    // This only detects caches where the "outermost" cache has the "prefixes unnecessary" label.
+    expect(prefixesAreUnnecessaryForIsolation(prefixing)).toBe(false);
   });
 });

--- a/packages/keyValueCache/src/index.ts
+++ b/packages/keyValueCache/src/index.ts
@@ -1,8 +1,4 @@
 export type { KeyValueCache, KeyValueCacheSetOptions } from "./KeyValueCache";
-export {
-  PrefixingKeyValueCache,
-  PrefixesAreUnnecessaryForIsolationCache,
-  prefixesAreUnnecessaryForIsolation,
-} from "./PrefixingKeyValueCache";
+export { PrefixingKeyValueCache } from "./PrefixingKeyValueCache";
 export { InMemoryLRUCache } from "./InMemoryLRUCache";
 export { ErrorsAreMissesCache } from "./ErrorsAreMissesCache";

--- a/packages/keyValueCache/src/index.ts
+++ b/packages/keyValueCache/src/index.ts
@@ -1,4 +1,8 @@
 export type { KeyValueCache, KeyValueCacheSetOptions } from "./KeyValueCache";
-export { PrefixingKeyValueCache } from "./PrefixingKeyValueCache";
+export {
+  PrefixingKeyValueCache,
+  PrefixesAreUnnecessaryForIsolationCache,
+  prefixesAreUnnecessaryForIsolation,
+} from "./PrefixingKeyValueCache";
 export { InMemoryLRUCache } from "./InMemoryLRUCache";
 export { ErrorsAreMissesCache } from "./ErrorsAreMissesCache";


### PR DESCRIPTION
This allows software like Apollo Server plugins to "prefix" their provided cache by default, but still allow you to disable prefixes by passing in a specially "tagged" cache.

Part of apollographql/apollo-server#6742. Will close that issue once AS is updated to throw if one of these caches is provided to it. Also part of apollographql/datasource-rest#19.