### PR TITLE
Enforce `DataLoader` contract

### DIFF
--- a/.changeset/yellow-dogs-do.md
+++ b/.changeset/yellow-dogs-do.md
@@ -1,0 +1,12 @@
+---
+"@apollo/utils.keyvadapter": patch
+---
+
+Fix issue with KeyvAdapter where `Keyv.getMany` returns `undefined`,
+causing `KeyvAdapter` to violate the `DataLoader` contract.
+
+DataLoader always expects a `Promise<Array<V>>` having the same length
+as the `keys` that were given to it. This problem stems from a
+shortcoming of the `Keyv` typings, since it doesn't declare that a
+`get([...keys])` can return a singular `undefined` (but it can in
+the case of errors / `Store.getMany` can return a singular `undefined`).

--- a/packages/keyvAdapter/src/__tests__/KeyvAdapter.test.ts
+++ b/packages/keyvAdapter/src/__tests__/KeyvAdapter.test.ts
@@ -183,9 +183,7 @@ describe("KeyvAdapter", () => {
       const keyvAdapter = new KeyvAdapter(
         new Keyv({ store: new GetManyReturnsSingularUndefinedStore() }),
       );
-      await expect(keyvAdapter.get("abc")).rejects.toMatchInlineSnapshot(
-        `[TypeError: DataLoader must be constructed with a function which accepts Array<key> and returns Promise<Array<value>>, but the function did not return a Promise of an Array: undefined.]`,
-      );
+      await expect(keyvAdapter.get("abc")).resolves.toBeUndefined();
     });
   });
 });

--- a/packages/keyvAdapter/src/__tests__/KeyvAdapter.test.ts
+++ b/packages/keyvAdapter/src/__tests__/KeyvAdapter.test.ts
@@ -157,4 +157,35 @@ describe("KeyvAdapter", () => {
       expect(deleteSpy).toHaveBeenCalledWith("foo");
     });
   });
+
+  describe("Dataloader implementation details", () => {
+    it("enforces the Dataloader contract (1:1 key to value)", async () => {
+      class GetManyReturnsSingularUndefinedStore implements Store<string> {
+        getMany(_keys: string[]) {
+          // really we would prefer an array of undefined of the length of
+          // _keys, but that isn't a contract that `Keyv` enforces
+          return undefined;
+        }
+        get() {
+          return "hello";
+        }
+        set() {
+          return;
+        }
+        delete() {
+          return true;
+        }
+        clear() {
+          return;
+        }
+      }
+
+      const keyvAdapter = new KeyvAdapter(
+        new Keyv({ store: new GetManyReturnsSingularUndefinedStore() }),
+      );
+      await expect(keyvAdapter.get("abc")).rejects.toMatchInlineSnapshot(
+        `[TypeError: DataLoader must be constructed with a function which accepts Array<key> and returns Promise<Array<value>>, but the function did not return a Promise of an Array: undefined.]`,
+      );
+    });
+  });
 });

--- a/packages/keyvAdapter/src/index.ts
+++ b/packages/keyvAdapter/src/index.ts
@@ -22,7 +22,13 @@ export class KeyvAdapter<
     this.dataLoader = options?.disableBatchReads
       ? undefined
       : new DataLoader(
-          (keys) => this.keyv.get([...keys]),
+          async (keys) => {
+            const result = await this.keyv.get([...keys]);
+            if (!result) {
+              return [...Array(keys.length)];
+            }
+            return result;
+          },
           // We're not actually using `DataLoader` for its caching
           // capabilities, we're only interested in batching functionality
           { cache: false },


### PR DESCRIPTION
Fixes #256

As mentioned in the above issue, `KeyvAdapter` currently provides an invalid function to `DataLoader`. Though the types don't indicate it, `keyv.get(keys)`(the plural/array overload) is capable of returning `undefined` in the event that the underlying `Store.getMany` returns `undefined`. When this happens, `KeyvAdapter` violates `DataLoader`s expectations (and it throws an error).

We can defend against this by handling the `undefined` case and returning an array of `keys.length` filled with `undefined`.