### PR TITLE
Allow v3.8.0 prerelease versions of `@apollo/client`

### DIFF
--- a/.changeset/selfish-knives-flow.md
+++ b/.changeset/selfish-knives-flow.md
@@ -1,0 +1,6 @@
+---
+"@apollo/generate-persisted-query-manifest": patch
+"@apollo/persisted-query-lists": patch
+---
+
+Allow v3.8.0 prerelease versions of @apollo/client.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10014,7 +10014,7 @@
     },
     "packages/generate-persisted-query-manifest": {
       "name": "@apollo/generate-persisted-query-manifest",
-      "version": "1.0.0-alpha.0",
+      "version": "1.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/graphql-tag-pluck": "^8.0.0",
@@ -10028,7 +10028,7 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "@apollo/client": "^3.7.0",
+        "@apollo/client": "^3.7.0 || ^3.8.0-alpha",
         "graphql": "14.x || 15.x || 16.x"
       }
     },
@@ -10164,13 +10164,13 @@
     },
     "packages/persisted-query-lists": {
       "name": "@apollo/persisted-query-lists",
-      "version": "1.0.0-alpha.0",
+      "version": "1.0.0-alpha.1",
       "license": "MIT",
       "engines": {
         "node": ">=16"
       },
       "peerDependencies": {
-        "@apollo/client": "^3.2.0",
+        "@apollo/client": "^3.2.0 || ^3.8.0-alpha",
         "graphql": "14.x || 15.x || 16.x"
       }
     },

--- a/packages/generate-persisted-query-manifest/package.json
+++ b/packages/generate-persisted-query-manifest/package.json
@@ -29,7 +29,7 @@
     "lodash": "^4.17.21"
   },
   "peerDependencies": {
-    "@apollo/client": "^3.7.0",
+    "@apollo/client": "^3.7.0 || ^3.8.0-alpha",
     "graphql": "14.x || 15.x || 16.x"
   }
 }

--- a/packages/persisted-query-lists/package.json
+++ b/packages/persisted-query-lists/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "@apollo/client": "^3.2.0",
+    "@apollo/client": "^3.2.0 || ^3.8.0-alpha",
     "graphql": "14.x || 15.x || 16.x"
   }
 }


### PR DESCRIPTION
When installing the packages to extract the manifest file, npm would warn about the incorrect peer dependency version. This PR ensure the current `v3.8.0` alpha and beta releases can also be used.