### PR TITLE
Add support for a config file to the `generate-persisted-query-manifeest` CLI

### DIFF
--- a/.changeset/moody-pots-promise.md
+++ b/.changeset/moody-pots-promise.md
@@ -1,0 +1,5 @@
+---
+"@apollo/generate-persisted-query-manifest": patch
+---
+
+Adds support for a config file to the CLI. This can be used to determine where the CLI should look for GraphQL operations and where the manifest file should be written. The CLI has the ability to specify the path to the config file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -935,7 +935,6 @@
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -2134,22 +2133,18 @@
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.8",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.9",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/babel__core": {
@@ -2310,8 +2305,7 @@
     "node_modules/@types/node": {
       "version": "16.18.32",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.32.tgz",
-      "integrity": "sha512-zpnXe4dEz6PrWz9u7dqyRoq9VxwCvoXRPy/ewhmMa1CgEyVmtL1NJPQ2MX+4pf97vetquVKkpiMx0MwI8pjNOw==",
-      "dev": true
+      "integrity": "sha512-zpnXe4dEz6PrWz9u7dqyRoq9VxwCvoXRPy/ewhmMa1CgEyVmtL1NJPQ2MX+4pf97vetquVKkpiMx0MwI8pjNOw=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.4",
@@ -2647,7 +2641,6 @@
       "version": "8.8.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
       "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
-      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2668,7 +2661,6 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -2780,7 +2772,6 @@
     },
     "node_modules/arg": {
       "version": "4.1.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -3218,7 +3209,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -3423,9 +3413,56 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
     },
+    "node_modules/cosmiconfig": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.1.3.tgz",
+      "integrity": "sha512-/UkO2JKI18b5jVMJUp0lvKFMpa/Gye+ZgZjKD+DGEN9y7NRcf/nK1A0sp67ONmKtnDCNMS44E6jrk0Yc3bDuUw==",
+      "dependencies": {
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      }
+    },
+    "node_modules/cosmiconfig-typescript-loader": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.3.0.tgz",
+      "integrity": "sha512-NTxV1MFfZDLPiBMjxbHRwSh5LaLcPMwNdCutmnHJCKoVnlvldPWlllonKwrsRJ5pYZBIBGRWWU2tfvzxgeSW5Q==",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "cosmiconfig": ">=7",
+        "ts-node": ">=10",
+        "typescript": ">=3"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/cosmiconfig/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -3620,7 +3657,6 @@
     },
     "node_modules/diff": {
       "version": "4.0.2",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -3748,7 +3784,6 @@
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -4859,7 +4894,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-      "dev": true,
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -4875,7 +4909,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -4948,7 +4981,6 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-bigint": {
@@ -6996,7 +7028,6 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -7084,7 +7115,6 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/load-yaml-file": {
@@ -7243,7 +7273,6 @@
     },
     "node_modules/make-error": {
       "version": "1.3.6",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/make-fetch-happen": {
@@ -7877,7 +7906,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -7887,7 +7915,6 @@
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -7964,7 +7991,6 @@
     },
     "node_modules/path-type": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9322,7 +9348,6 @@
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
       "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "dev": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -9523,7 +9548,6 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
       "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9615,7 +9639,6 @@
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
@@ -9951,7 +9974,6 @@
     },
     "node_modules/yn": {
       "version": "3.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10019,6 +10041,8 @@
       "dependencies": {
         "@apollo/persisted-query-lists": "^1.0.0-alpha.2",
         "@graphql-tools/graphql-tag-pluck": "^8.0.0",
+        "cosmiconfig": "^8.1.3",
+        "cosmiconfig-typescript-loader": "^4.3.0",
         "glob": "^10.2.6",
         "lodash": "^4.17.21"
       },
@@ -10282,6 +10306,8 @@
       "requires": {
         "@apollo/persisted-query-lists": "^1.0.0-alpha.2",
         "@graphql-tools/graphql-tag-pluck": "^8.0.0",
+        "cosmiconfig": "^8.1.3",
+        "cosmiconfig-typescript-loader": "^4.3.0",
         "glob": "^10.2.6",
         "lodash": "^4.17.21"
       },
@@ -11002,7 +11028,6 @@
     },
     "@cspotcode/source-map-support": {
       "version": "0.8.1",
-      "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "0.3.9"
       }
@@ -11903,20 +11928,16 @@
       "dev": true
     },
     "@tsconfig/node10": {
-      "version": "1.0.8",
-      "dev": true
+      "version": "1.0.8"
     },
     "@tsconfig/node12": {
-      "version": "1.0.9",
-      "dev": true
+      "version": "1.0.9"
     },
     "@tsconfig/node14": {
-      "version": "1.0.1",
-      "dev": true
+      "version": "1.0.1"
     },
     "@tsconfig/node16": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "@types/babel__core": {
       "version": "7.20.0",
@@ -12065,8 +12086,7 @@
     "@types/node": {
       "version": "16.18.32",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.32.tgz",
-      "integrity": "sha512-zpnXe4dEz6PrWz9u7dqyRoq9VxwCvoXRPy/ewhmMa1CgEyVmtL1NJPQ2MX+4pf97vetquVKkpiMx0MwI8pjNOw==",
-      "dev": true
+      "integrity": "sha512-zpnXe4dEz6PrWz9u7dqyRoq9VxwCvoXRPy/ewhmMa1CgEyVmtL1NJPQ2MX+4pf97vetquVKkpiMx0MwI8pjNOw=="
     },
     "@types/node-fetch": {
       "version": "2.6.4",
@@ -12285,8 +12305,7 @@
     "acorn": {
       "version": "8.8.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
-      "dev": true
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw=="
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -12298,8 +12317,7 @@
     "acorn-walk": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-      "dev": true
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
     },
     "agent-base": {
       "version": "6.0.2",
@@ -12370,8 +12388,7 @@
       }
     },
     "arg": {
-      "version": "4.1.3",
-      "dev": true
+      "version": "4.1.3"
     },
     "argparse": {
       "version": "1.0.10",
@@ -12678,8 +12695,7 @@
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
     "camelcase": {
       "version": "5.3.1",
@@ -12818,9 +12834,40 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
     },
+    "cosmiconfig": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.1.3.tgz",
+      "integrity": "sha512-/UkO2JKI18b5jVMJUp0lvKFMpa/Gye+ZgZjKD+DGEN9y7NRcf/nK1A0sp67ONmKtnDCNMS44E6jrk0Yc3bDuUw==",
+      "requires": {
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        }
+      }
+    },
+    "cosmiconfig-typescript-loader": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.3.0.tgz",
+      "integrity": "sha512-NTxV1MFfZDLPiBMjxbHRwSh5LaLcPMwNdCutmnHJCKoVnlvldPWlllonKwrsRJ5pYZBIBGRWWU2tfvzxgeSW5Q==",
+      "requires": {}
+    },
     "create-require": {
-      "version": "1.1.1",
-      "dev": true
+      "version": "1.1.1"
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -12950,8 +12997,7 @@
       "dev": true
     },
     "diff": {
-      "version": "4.0.2",
-      "dev": true
+      "version": "4.0.2"
     },
     "diff-sequences": {
       "version": "29.4.3",
@@ -13039,7 +13085,6 @@
     },
     "error-ex": {
       "version": "1.3.2",
-      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -13817,7 +13862,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-      "dev": true,
       "requires": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -13826,8 +13870,7 @@
         "resolve-from": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-          "dev": true
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
         }
       }
     },
@@ -13874,8 +13917,7 @@
       "dev": true
     },
     "is-arrayish": {
-      "version": "0.2.1",
-      "dev": true
+      "version": "0.2.1"
     },
     "is-bigint": {
       "version": "1.0.4",
@@ -15336,8 +15378,7 @@
       "version": "3.0.1"
     },
     "json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "dev": true
+      "version": "2.3.1"
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -15401,8 +15442,7 @@
       }
     },
     "lines-and-columns": {
-      "version": "1.2.4",
-      "dev": true
+      "version": "1.2.4"
     },
     "load-yaml-file": {
       "version": "0.2.0",
@@ -15521,8 +15561,7 @@
       }
     },
     "make-error": {
-      "version": "1.3.6",
-      "dev": true
+      "version": "1.3.6"
     },
     "make-fetch-happen": {
       "version": "11.1.1",
@@ -15969,14 +16008,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "requires": {
         "callsites": "^3.0.0"
       }
     },
     "parse-json": {
       "version": "5.2.0",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -16023,8 +16060,7 @@
       }
     },
     "path-type": {
-      "version": "4.0.0",
-      "dev": true
+      "version": "4.0.0"
     },
     "picocolors": {
       "version": "1.0.0"
@@ -16931,7 +16967,6 @@
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
       "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "dev": true,
       "requires": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -17064,8 +17099,7 @@
     "typescript": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
-      "dev": true
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw=="
     },
     "unbox-primitive": {
       "version": "1.0.2",
@@ -17128,8 +17162,7 @@
       "dev": true
     },
     "v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "dev": true
+      "version": "3.0.1"
     },
     "v8-to-istanbul": {
       "version": "9.1.0",
@@ -17393,8 +17426,7 @@
       }
     },
     "yn": {
-      "version": "3.1.1",
-      "dev": true
+      "version": "3.1.1"
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10044,10 +10044,10 @@
     },
     "packages/generate-persisted-query-manifest": {
       "name": "@apollo/generate-persisted-query-manifest",
-      "version": "1.0.0-alpha.2",
+      "version": "1.0.0-alpha.3",
       "license": "MIT",
       "dependencies": {
-        "@apollo/persisted-query-lists": "^1.0.0-alpha.2",
+        "@apollo/persisted-query-lists": "^1.0.0-alpha.3",
         "@graphql-tools/graphql-tag-pluck": "^8.0.0",
         "commander": "^10.0.1",
         "cosmiconfig": "^8.1.3",
@@ -10198,7 +10198,7 @@
     },
     "packages/persisted-query-lists": {
       "name": "@apollo/persisted-query-lists",
-      "version": "1.0.0-alpha.2",
+      "version": "1.0.0-alpha.3",
       "license": "MIT",
       "engines": {
         "node": ">=16"
@@ -10313,7 +10313,7 @@
     "@apollo/generate-persisted-query-manifest": {
       "version": "file:packages/generate-persisted-query-manifest",
       "requires": {
-        "@apollo/persisted-query-lists": "^1.0.0-alpha.2",
+        "@apollo/persisted-query-lists": "^1.0.0-alpha.3",
         "@graphql-tools/graphql-tag-pluck": "^8.0.0",
         "commander": "^10.0.1",
         "cosmiconfig": "^8.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3392,6 +3392,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/compress-brotli": {
       "version": "1.3.8",
       "license": "MIT",
@@ -10041,6 +10049,7 @@
       "dependencies": {
         "@apollo/persisted-query-lists": "^1.0.0-alpha.2",
         "@graphql-tools/graphql-tag-pluck": "^8.0.0",
+        "commander": "^10.0.1",
         "cosmiconfig": "^8.1.3",
         "cosmiconfig-typescript-loader": "^4.3.0",
         "glob": "^10.2.6",
@@ -10306,6 +10315,7 @@
       "requires": {
         "@apollo/persisted-query-lists": "^1.0.0-alpha.2",
         "@graphql-tools/graphql-tag-pluck": "^8.0.0",
+        "commander": "^10.0.1",
         "cosmiconfig": "^8.1.3",
         "cosmiconfig-typescript-loader": "^4.3.0",
         "glob": "^10.2.6",
@@ -12817,6 +12827,11 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
     },
     "compress-brotli": {
       "version": "1.3.8",

--- a/packages/generate-persisted-query-manifest/cli.js
+++ b/packages/generate-persisted-query-manifest/cli.js
@@ -5,6 +5,7 @@ const { cosmiconfig } = require("cosmiconfig");
 const { generatePersistedQueryManifest, defaults } = require("./dist/index.js");
 const { TypeScriptLoader } = require("cosmiconfig-typescript-loader");
 const { version } = require("./package.json");
+const { writeFileSync } = require("node:fs");
 
 const program = new Command();
 
@@ -36,8 +37,10 @@ program
     const result = await getUserConfig(cliOptions);
     const outputPath = result?.config.output ?? defaults.output;
 
-    await generatePersistedQueryManifest(result?.config);
-    console.log(`Written to ${outputPath}`);
+    const manifest = await generatePersistedQueryManifest(result?.config);
+    writeFileSync(outputPath, JSON.stringify(manifest, null, 2));
+
+    console.log(`Manifest written to ${outputPath}`);
   });
 
 program.parse();

--- a/packages/generate-persisted-query-manifest/cli.js
+++ b/packages/generate-persisted-query-manifest/cli.js
@@ -23,23 +23,8 @@ const explorer = cosmiconfig(moduleName, {
   },
 });
 
-async function getUserConfig(cliOptions) {
-  const { config: configPath } = cliOptions;
-
+async function getUserConfig({ config: configPath }) {
   return configPath ? explorer.load(configPath) : explorer.search();
-}
-
-async function main(cliOptions) {
-  try {
-    const result = await getUserConfig(cliOptions);
-    const outputPath = result?.config.output ?? defaults.output;
-
-    await generatePersistedQueryManifest(result?.config);
-    console.log(`Written to ${outputPath}`);
-  } catch (e) {
-    console.error(e);
-    process.exit(1);
-  }
 }
 
 program
@@ -47,6 +32,17 @@ program
   .description("Generate a persisted query manifest file")
   .option("-c, --config <path>", "path to the config file")
   .version(version, "-v, --version")
-  .parse();
+  .action(async (cliOptions) => {
+    try {
+      const result = await getUserConfig(cliOptions);
+      const outputPath = result?.config.output ?? defaults.output;
 
-main(program.opts());
+      await generatePersistedQueryManifest(result?.config);
+      console.log(`Written to ${outputPath}`);
+    } catch (e) {
+      console.error(e);
+      process.exit(1);
+    }
+  });
+
+program.parse();

--- a/packages/generate-persisted-query-manifest/cli.js
+++ b/packages/generate-persisted-query-manifest/cli.js
@@ -1,8 +1,11 @@
 #!/usr/bin/env node
 
+const { Command } = require("commander");
 const { cosmiconfig } = require("cosmiconfig");
 const { generatePersistedQueryManifest, defaults } = require("./dist/index.js");
 const { TypeScriptLoader } = require("cosmiconfig-typescript-loader");
+
+const program = new Command();
 
 const moduleName = "persisted-query-manifest";
 const supportedExtensions = ["json", "yml", "yaml", "js", "ts", "cjs"];
@@ -19,9 +22,15 @@ const explorer = cosmiconfig(moduleName, {
   },
 });
 
-async function main() {
+async function getUserConfig(cliOptions) {
+  const { config: configPath } = cliOptions;
+
+  return configPath ? explorer.load(configPath) : explorer.search();
+}
+
+async function main(cliOptions) {
   try {
-    const result = await explorer.search();
+    const result = await getUserConfig(cliOptions);
     const outputPath = result?.config.output ?? defaults.output;
 
     await generatePersistedQueryManifest(result?.config);
@@ -32,4 +41,10 @@ async function main() {
   }
 }
 
-main();
+program
+  .name("generate-persisted-query-manifest")
+  .description("Generate a persisted query manifest file")
+  .option("-c, --config <path>", "path to the config file")
+  .parse();
+
+main(program.opts());

--- a/packages/generate-persisted-query-manifest/cli.js
+++ b/packages/generate-persisted-query-manifest/cli.js
@@ -1,8 +1,27 @@
 #!/usr/bin/env node
 
+const { cosmiconfig } = require("cosmiconfig");
 const { generatePersistedQueryManifest } = require("./dist/index.js");
+const { TypeScriptLoader } = require("cosmiconfig-typescript-loader");
 
-generatePersistedQueryManifest()
+const moduleName = "persisted-query-manifest";
+const supportedExtensions = ["json", "yml", "yaml", "js", "ts", "cjs"];
+
+const searchPlaces = supportedExtensions.flatMap((extension) => [
+  `.${moduleName}.config.${extension}`,
+  `${moduleName}.config.${extension}`,
+]);
+
+const explorer = cosmiconfig(moduleName, {
+  searchPlaces: searchPlaces.concat("package.json"),
+  loaders: {
+    ".ts": TypeScriptLoader(),
+  },
+});
+
+explorer
+  .search()
+  .then(() => generatePersistedQueryManifest())
   .then((manifest) => console.log(JSON.stringify(manifest, null, 2)))
   .catch((e) => {
     console.error(e);

--- a/packages/generate-persisted-query-manifest/cli.js
+++ b/packages/generate-persisted-query-manifest/cli.js
@@ -21,7 +21,7 @@ const explorer = cosmiconfig(moduleName, {
 
 explorer
   .search()
-  .then(() => generatePersistedQueryManifest())
+  .then((result) => generatePersistedQueryManifest(result?.config))
   .then((manifest) => console.log(JSON.stringify(manifest, null, 2)))
   .catch((e) => {
     console.error(e);

--- a/packages/generate-persisted-query-manifest/cli.js
+++ b/packages/generate-persisted-query-manifest/cli.js
@@ -4,6 +4,7 @@ const { Command } = require("commander");
 const { cosmiconfig } = require("cosmiconfig");
 const { generatePersistedQueryManifest, defaults } = require("./dist/index.js");
 const { TypeScriptLoader } = require("cosmiconfig-typescript-loader");
+const { version } = require("./package.json");
 
 const program = new Command();
 
@@ -45,6 +46,7 @@ program
   .name("generate-persisted-query-manifest")
   .description("Generate a persisted query manifest file")
   .option("-c, --config <path>", "path to the config file")
+  .version(version, "-v, --version")
   .parse();
 
 main(program.opts());

--- a/packages/generate-persisted-query-manifest/cli.js
+++ b/packages/generate-persisted-query-manifest/cli.js
@@ -33,16 +33,11 @@ program
   .option("-c, --config <path>", "path to the config file")
   .version(version, "-v, --version")
   .action(async (cliOptions) => {
-    try {
-      const result = await getUserConfig(cliOptions);
-      const outputPath = result?.config.output ?? defaults.output;
+    const result = await getUserConfig(cliOptions);
+    const outputPath = result?.config.output ?? defaults.output;
 
-      await generatePersistedQueryManifest(result?.config);
-      console.log(`Written to ${outputPath}`);
-    } catch (e) {
-      console.error(e);
-      process.exit(1);
-    }
+    await generatePersistedQueryManifest(result?.config);
+    console.log(`Written to ${outputPath}`);
   });
 
 program.parse();

--- a/packages/generate-persisted-query-manifest/cli.js
+++ b/packages/generate-persisted-query-manifest/cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const { cosmiconfig } = require("cosmiconfig");
-const { generatePersistedQueryManifest } = require("./dist/index.js");
+const { generatePersistedQueryManifest, defaults } = require("./dist/index.js");
 const { TypeScriptLoader } = require("cosmiconfig-typescript-loader");
 
 const moduleName = "persisted-query-manifest";
@@ -19,11 +19,17 @@ const explorer = cosmiconfig(moduleName, {
   },
 });
 
-explorer
-  .search()
-  .then((result) => generatePersistedQueryManifest(result?.config))
-  .then((manifest) => console.log(JSON.stringify(manifest, null, 2)))
-  .catch((e) => {
+async function main() {
+  try {
+    const result = await explorer.search();
+    const outputPath = result?.config.output ?? defaults.output;
+
+    await generatePersistedQueryManifest(result?.config);
+    console.log(`Written to ${outputPath}`);
+  } catch (e) {
     console.error(e);
     process.exit(1);
-  });
+  }
+}
+
+main();

--- a/packages/generate-persisted-query-manifest/package.json
+++ b/packages/generate-persisted-query-manifest/package.json
@@ -26,6 +26,8 @@
   "dependencies": {
     "@apollo/persisted-query-lists": "^1.0.0-alpha.3",
     "@graphql-tools/graphql-tag-pluck": "^8.0.0",
+    "cosmiconfig": "^8.1.3",
+    "cosmiconfig-typescript-loader": "^4.3.0",
     "glob": "^10.2.6",
     "lodash": "^4.17.21"
   },

--- a/packages/generate-persisted-query-manifest/package.json
+++ b/packages/generate-persisted-query-manifest/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@apollo/persisted-query-lists": "^1.0.0-alpha.3",
     "@graphql-tools/graphql-tag-pluck": "^8.0.0",
+    "commander": "^10.0.1",
     "cosmiconfig": "^8.1.3",
     "cosmiconfig-typescript-loader": "^4.3.0",
     "glob": "^10.2.6",

--- a/packages/generate-persisted-query-manifest/src/index.ts
+++ b/packages/generate-persisted-query-manifest/src/index.ts
@@ -19,12 +19,24 @@ import { first, sortBy } from "lodash";
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 
-export interface GeneratePersistedQueryManifestOptions {
-  files?: string[];
+type RequireKeys<T, K extends keyof T> = Required<Pick<T, K>> & Omit<T, K>;
 
-  globInclude?: string[];
-  globExclude?: string[];
+export interface PersistedQueryManifestConfig {
+  /**
+   * Paths to your GraphQL documents: queries, mutations, subscriptions, and fragments.
+   */
+  documents?: string | string[];
+
+  /**
+   * Paths that should be ignored when searching for your GraphQL documents.
+   */
+  documentIgnorePatterns?: string | string[];
 }
+
+type DefaultPersistedQueryManifestConfig = RequireKeys<
+  PersistedQueryManifestConfig,
+  "documents" | "documentIgnorePatterns"
+>;
 
 export interface PersistedQueryManifestOperation {
   id: string;
@@ -32,28 +44,33 @@ export interface PersistedQueryManifestOperation {
   type: "query" | "mutation" | "subscription";
   body: string;
 }
+
 export interface PersistedQueryManifest {
   format: "apollo-persisted-query-manifest";
   version: 1;
   operations: PersistedQueryManifestOperation[];
 }
 
-export async function generatePersistedQueryManifest(
-  options: GeneratePersistedQueryManifestOptions = {},
-): Promise<PersistedQueryManifest> {
-  const files = new Set<string>(options.files ?? []);
-  const globInclude = options.globInclude ?? [
-    "src/**/*.{graphql,tsx,jsx,ts,js}",
-  ];
-  const globExclude = options.globExclude ?? [
+export const defaults: DefaultPersistedQueryManifestConfig = {
+  documents: "src/**/*.{graphql,js,jsx,ts,tsx}",
+  documentIgnorePatterns: [
+    "**/*.d.ts",
     "**/*.spec.{js,jsx,ts,tsx}",
     "**/*.story.{js,jsx,ts,tsx}",
     "**/*.test.{js,jsx,ts,tsx}",
-  ];
-  for (const include of globInclude) {
-    for (const f of await glob(include, { ignore: globExclude ?? [] })) {
-      files.add(f);
-    }
+  ],
+};
+
+export async function generatePersistedQueryManifest(
+  config: PersistedQueryManifestConfig = {},
+): Promise<PersistedQueryManifest> {
+  const files = new Set<string>();
+  const paths = config.documents ?? defaults.documents;
+  const ignorePaths =
+    config.documentIgnorePatterns ?? defaults.documentIgnorePatterns;
+
+  for (const f of await glob(paths, { ignore: ignorePaths })) {
+    files.add(f);
   }
 
   const documents = [...files].flatMap((filePath) => {

--- a/packages/generate-persisted-query-manifest/src/index.ts
+++ b/packages/generate-persisted-query-manifest/src/index.ts
@@ -17,7 +17,7 @@ import {
 } from "graphql";
 import { first, sortBy } from "lodash";
 import { createHash } from "node:crypto";
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 
 type RequireKeys<T, K extends keyof T> = Required<Pick<T, K>> & Omit<T, K>;
 
@@ -69,7 +69,7 @@ export const defaults: DefaultPersistedQueryManifestConfig = {
 
 export async function generatePersistedQueryManifest(
   config: PersistedQueryManifestConfig = {},
-): Promise<void> {
+): Promise<PersistedQueryManifest> {
   const files = new Set<string>();
   const paths = config.documents ?? defaults.documents;
   const ignorePaths =
@@ -163,16 +163,9 @@ export async function generatePersistedQueryManifest(
     await client.query({ query: document, fetchPolicy: "no-cache" });
   }
 
-  writeFileSync(
-    config.output ?? defaults.output,
-    JSON.stringify(
-      {
-        format: "apollo-persisted-query-manifest",
-        version: 1,
-        operations: manifestOperations,
-      },
-      null,
-      2,
-    ),
-  );
+  return {
+    format: "apollo-persisted-query-manifest",
+    version: 1,
+    operations: manifestOperations,
+  };
 }

--- a/packages/generate-persisted-query-manifest/src/index.ts
+++ b/packages/generate-persisted-query-manifest/src/index.ts
@@ -57,7 +57,7 @@ export interface PersistedQueryManifest {
 }
 
 export const defaults: DefaultPersistedQueryManifestConfig = {
-  documents: "src/**/*.{graphql,js,jsx,ts,tsx}",
+  documents: "src/**/*.{graphql,gql,js,jsx,ts,tsx}",
   documentIgnorePatterns: [
     "**/*.d.ts",
     "**/*.spec.{js,jsx,ts,tsx}",


### PR DESCRIPTION
The CLI can now take a config file that will be used for the operation extraction. The CLI uses [`cosmiconfig`](https://github.com/cosmiconfig/cosmiconfig) and will, by default, search for a config file in these locations:

const supportedExtensions = ["json", "yml", "yaml", "js", "ts", "cjs"];

- `.persisted-query-manifest.config.json`
- `persisted-query-manifest.config.json`
- `.persisted-query-manifest.config.yml`
- `persisted-query-manifest.config.yml`
- `.persisted-query-manifest.config.yaml`
- `persisted-query-manifest.config.yaml`
- `.persisted-query-manifest.config.js`
- `persisted-query-manifest.config.js`
- `.persisted-query-manifest.config.ts`
- `persisted-query-manifest.config.ts`
- `.persisted-query-manifest.config.cjs`
- `persisted-query-manifest.config.cjs`

Or a `persisted-query-manifest` key in `package.json`.

You can also provide the location of the config file with the `--config` option to the CLI:

```
npx generate-persisted-query-manifest --config path/to/persisted-query-manifest.config.ts
```

The config file can be configured with the following options:

- `documents` (`string | string[]`) - The glob patterns where the CLI tool should search for GraphQL operations. 
  - Defaults to `src/**/*.{graphql,js,jsx,ts,tsx}`.
- `documentIgnorePatterns` (`string | string[]`) - Glob patterns where the tool should exclude searching for GraphQL operations. 
  - Defaults to `["**/*.d.ts", "**/*.spec.{js,jsx,ts,tsx}", "**/*.story.{js,jsx,ts,tsx}", "**/*.test.{js,jsx,ts,tsx}"]`
- `output` (`string`) - Path where the manifest should be written.
  - Defaults to `persisted-query-manifest.json`

Example:

```ts
// persisted-query-manifest.config.ts
import { PersistedQueryManifestConfig } from '@apollo/generate-persisted-query-manifest';

const config: PersistedQueryManifestConfig = {
  documents: 'path/to/documents/**/*.{ts,tsx}'
};

export default config;
``` 