### PR TITLE
Update usage reporting protobuf dependency (version 2 backport)

### DIFF
--- a/.changeset/yellow-clouds-taste.md
+++ b/.changeset/yellow-clouds-taste.md
@@ -1,0 +1,5 @@
+---
+"@apollo/utils.usagereporting": minor
+---
+
+Update usage reporting protobuf which introduces support for the `ConditionNode` in query planning.

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,9 +58,9 @@
       }
     },
     "node_modules/@apollo/usage-reporting-protobuf": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@apollo/usage-reporting-protobuf/-/usage-reporting-protobuf-4.0.2.tgz",
-      "integrity": "sha512-GfE8aDqi/lAFut95pjH9IRvH0zGsQ5G/2lYL0ZLZfML7ArX+A4UVHFANQcPCcUYGE6bI6OPhLekg4Vsjf6B1cw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@apollo/usage-reporting-protobuf/-/usage-reporting-protobuf-4.1.0.tgz",
+      "integrity": "sha512-hXouMuw5pQVkzi8dgMybmr6Y11+eRmMQVoB5TF0HyTwAg9SOq/v3OCuiYqcVUKdBcskU9Msp+XvjAk0GKpWCwQ==",
       "dependencies": {
         "@apollo/protobufjs": "1.2.7"
       }
@@ -9693,7 +9693,7 @@
       "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
-        "@apollo/usage-reporting-protobuf": "^4.0.0",
+        "@apollo/usage-reporting-protobuf": "^4.1.0",
         "@apollo/utils.dropunuseddefinitions": "^2.0.1",
         "@apollo/utils.printwithreducedwhitespace": "^2.0.1",
         "@apollo/utils.removealiases": "2.0.1",
@@ -9725,9 +9725,9 @@
       }
     },
     "@apollo/usage-reporting-protobuf": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@apollo/usage-reporting-protobuf/-/usage-reporting-protobuf-4.0.2.tgz",
-      "integrity": "sha512-GfE8aDqi/lAFut95pjH9IRvH0zGsQ5G/2lYL0ZLZfML7ArX+A4UVHFANQcPCcUYGE6bI6OPhLekg4Vsjf6B1cw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@apollo/usage-reporting-protobuf/-/usage-reporting-protobuf-4.1.0.tgz",
+      "integrity": "sha512-hXouMuw5pQVkzi8dgMybmr6Y11+eRmMQVoB5TF0HyTwAg9SOq/v3OCuiYqcVUKdBcskU9Msp+XvjAk0GKpWCwQ==",
       "requires": {
         "@apollo/protobufjs": "1.2.7"
       },
@@ -9836,7 +9836,7 @@
     "@apollo/utils.usagereporting": {
       "version": "file:packages/usageReporting",
       "requires": {
-        "@apollo/usage-reporting-protobuf": "^4.0.0",
+        "@apollo/usage-reporting-protobuf": "^4.1.0",
         "@apollo/utils.dropunuseddefinitions": "^2.0.1",
         "@apollo/utils.printwithreducedwhitespace": "^2.0.1",
         "@apollo/utils.removealiases": "2.0.1",

--- a/packages/usageReporting/package.json
+++ b/packages/usageReporting/package.json
@@ -21,7 +21,7 @@
     "node": ">=14"
   },
   "dependencies": {
-    "@apollo/usage-reporting-protobuf": "^4.0.0",
+    "@apollo/usage-reporting-protobuf": "^4.1.0",
     "@apollo/utils.dropunuseddefinitions": "^2.0.1",
     "@apollo/utils.stripsensitiveliterals": "^2.0.1",
     "@apollo/utils.printwithreducedwhitespace": "^2.0.1",


### PR DESCRIPTION
This dependency update adds support the `ConditionNode`. Currently, the gateway interface package already has this update. When Apollo Server and Gateway are run in tandem this can lead to duplicate / conflicting versions of the `@apollo/usage-reporting-protobuf` package being installed under specific circumstances. This version bump ensures that users running the latest versions of these packages don't run into this.

Backport of #299 