### PR TITLE
Better error handling

### DIFF
--- a/.changeset/weak-monkeys-reflect.md
+++ b/.changeset/weak-monkeys-reflect.md
@@ -1,0 +1,8 @@
+---
+"@apollo/generate-persisted-query-manifest": patch
+---
+
+Provides more robust error handling and reporting.
+
+* Collect all errors while generating manifest and report them together at once. Previously it would exit as soon as an error was encountered, even if there were multiple issues.
+* Update the error reporting format to make it much easier to determine which file contains the error.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10170,6 +10170,7 @@
       "dependencies": {
         "@apollo/persisted-query-lists": "^1.0.0-alpha.3",
         "@graphql-tools/graphql-tag-pluck": "^8.0.0",
+        "chalk": "^4.1.2",
         "commander": "^10.0.1",
         "cosmiconfig": "^8.1.3",
         "cosmiconfig-typescript-loader": "^4.3.0",
@@ -10189,6 +10190,20 @@
         "graphql": "14.x || 15.x || 16.x"
       }
     },
+    "packages/generate-persisted-query-manifest/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "packages/generate-persisted-query-manifest/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -10196,6 +10211,37 @@
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
+    },
+    "packages/generate-persisted-query-manifest/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "packages/generate-persisted-query-manifest/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "packages/generate-persisted-query-manifest/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "packages/generate-persisted-query-manifest/node_modules/glob": {
       "version": "10.2.6",
@@ -10218,6 +10264,14 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "packages/generate-persisted-query-manifest/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "packages/generate-persisted-query-manifest/node_modules/minimatch": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
@@ -10238,6 +10292,17 @@
       "integrity": "sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "packages/generate-persisted-query-manifest/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "packages/isNodeLike": {
@@ -10438,6 +10503,7 @@
       "requires": {
         "@apollo/persisted-query-lists": "^1.0.0-alpha.3",
         "@graphql-tools/graphql-tag-pluck": "^8.0.0",
+        "chalk": "^4.1.2",
         "commander": "^10.0.1",
         "cosmiconfig": "^8.1.3",
         "cosmiconfig-typescript-loader": "^4.3.0",
@@ -10447,6 +10513,14 @@
         "vfile-reporter": "^6.0.2"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
         "brace-expansion": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -10454,6 +10528,28 @@
           "requires": {
             "balanced-match": "^1.0.0"
           }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "glob": {
           "version": "10.2.6",
@@ -10467,6 +10563,11 @@
             "path-scurry": "^1.7.0"
           }
         },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
         "minimatch": {
           "version": "9.0.1",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
@@ -10479,6 +10580,14 @@
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.2.tgz",
           "integrity": "sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2352,6 +2352,11 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
     },
+    "node_modules/@types/unist": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
+      "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.10",
       "dev": true,
@@ -5017,6 +5022,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/is-callable": {
@@ -8390,6 +8417,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "dev": true,
@@ -9615,6 +9650,18 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/unist-util-stringify-position": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
+      "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
+      "dependencies": {
+        "@types/unist": "^2.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "dev": true,
@@ -9680,6 +9727,80 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
+      "integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0",
+        "vfile-message": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
+      "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-reporter": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-reporter/-/vfile-reporter-6.0.2.tgz",
+      "integrity": "sha512-GN2bH2gs4eLnw/4jPSgfBjo+XCuvnX9elHICJZjVD4+NM0nsUrMTvdjGY5Sc/XG69XVTgLwj7hknQVc6M9FukA==",
+      "dependencies": {
+        "repeat-string": "^1.5.0",
+        "string-width": "^4.0.0",
+        "supports-color": "^6.0.0",
+        "unist-util-stringify-position": "^2.0.0",
+        "vfile-sort": "^2.1.2",
+        "vfile-statistics": "^1.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-reporter/node_modules/supports-color": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+      "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/vfile-sort": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/vfile-sort/-/vfile-sort-2.2.2.tgz",
+      "integrity": "sha512-tAyUqD2R1l/7Rn7ixdGkhXLD3zsg+XLAeUDUhXearjfIcpL1Hcsj5hHpCoy/gvfK/Ws61+e972fm0F7up7hfYA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-statistics": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/vfile-statistics/-/vfile-statistics-1.1.4.tgz",
+      "integrity": "sha512-lXhElVO0Rq3frgPvFBwahmed3X03vjPF8OcjKMy8+F1xU/3Q3QU3tKEDp743SFtb74PdF0UWpxPvtOP0GCLheA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/walker": {
@@ -10044,7 +10165,7 @@
     },
     "packages/generate-persisted-query-manifest": {
       "name": "@apollo/generate-persisted-query-manifest",
-      "version": "1.0.0-alpha.3",
+      "version": "1.0.0-alpha.4",
       "license": "MIT",
       "dependencies": {
         "@apollo/persisted-query-lists": "^1.0.0-alpha.3",
@@ -10053,7 +10174,9 @@
         "cosmiconfig": "^8.1.3",
         "cosmiconfig-typescript-loader": "^4.3.0",
         "glob": "^10.2.6",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.21",
+        "vfile": "^4.2.1",
+        "vfile-reporter": "^6.0.2"
       },
       "bin": {
         "generate-persisted-query-manifest": "cli.js"
@@ -10319,7 +10442,9 @@
         "cosmiconfig": "^8.1.3",
         "cosmiconfig-typescript-loader": "^4.3.0",
         "glob": "^10.2.6",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.21",
+        "vfile": "^4.2.1",
+        "vfile-reporter": "^6.0.2"
       },
       "dependencies": {
         "brace-expansion": {
@@ -12139,6 +12264,11 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
     },
+    "@types/unist": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
+      "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
+    },
     "@types/yargs": {
       "version": "17.0.10",
       "dev": true,
@@ -13952,6 +14082,11 @@
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
       }
+    },
+    "is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
     },
     "is-callable": {
       "version": "1.2.4",
@@ -16319,6 +16454,11 @@
         "functions-have-names": "^1.2.2"
       }
     },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w=="
+    },
     "require-directory": {
       "version": "2.1.1",
       "dev": true
@@ -17155,6 +17295,14 @@
         "imurmurhash": "^0.1.4"
       }
     },
+    "unist-util-stringify-position": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
+      "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
+      "requires": {
+        "@types/unist": "^2.0.2"
+      }
+    },
     "universalify": {
       "version": "0.1.2",
       "dev": true
@@ -17209,6 +17357,59 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "vfile": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
+      "integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0",
+        "vfile-message": "^2.0.0"
+      }
+    },
+    "vfile-message": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
+      "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0"
+      }
+    },
+    "vfile-reporter": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-reporter/-/vfile-reporter-6.0.2.tgz",
+      "integrity": "sha512-GN2bH2gs4eLnw/4jPSgfBjo+XCuvnX9elHICJZjVD4+NM0nsUrMTvdjGY5Sc/XG69XVTgLwj7hknQVc6M9FukA==",
+      "requires": {
+        "repeat-string": "^1.5.0",
+        "string-width": "^4.0.0",
+        "supports-color": "^6.0.0",
+        "unist-util-stringify-position": "^2.0.0",
+        "vfile-sort": "^2.1.2",
+        "vfile-statistics": "^1.1.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "vfile-sort": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/vfile-sort/-/vfile-sort-2.2.2.tgz",
+      "integrity": "sha512-tAyUqD2R1l/7Rn7ixdGkhXLD3zsg+XLAeUDUhXearjfIcpL1Hcsj5hHpCoy/gvfK/Ws61+e972fm0F7up7hfYA=="
+    },
+    "vfile-statistics": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/vfile-statistics/-/vfile-statistics-1.1.4.tgz",
+      "integrity": "sha512-lXhElVO0Rq3frgPvFBwahmed3X03vjPF8OcjKMy8+F1xU/3Q3QU3tKEDp743SFtb74PdF0UWpxPvtOP0GCLheA=="
     },
     "walker": {
       "version": "1.0.8",

--- a/packages/generate-persisted-query-manifest/package.json
+++ b/packages/generate-persisted-query-manifest/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@apollo/persisted-query-lists": "^1.0.0-alpha.3",
     "@graphql-tools/graphql-tag-pluck": "^8.0.0",
+    "chalk": "^4.1.2",
     "commander": "^10.0.1",
     "cosmiconfig": "^8.1.3",
     "cosmiconfig-typescript-loader": "^4.3.0",

--- a/packages/generate-persisted-query-manifest/package.json
+++ b/packages/generate-persisted-query-manifest/package.json
@@ -30,7 +30,9 @@
     "cosmiconfig": "^8.1.3",
     "cosmiconfig-typescript-loader": "^4.3.0",
     "glob": "^10.2.6",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "vfile": "^4.2.1",
+    "vfile-reporter": "^6.0.2"
   },
   "peerDependencies": {
     "@apollo/client": "^3.7.0 || ^3.8.0-alpha",

--- a/packages/generate-persisted-query-manifest/src/@types/vfile-reporter.d.ts
+++ b/packages/generate-persisted-query-manifest/src/@types/vfile-reporter.d.ts
@@ -9,5 +9,7 @@ declare module "vfile-reporter" {
     defaultName?: string;
   }
 
-  export function reporter(files: VFile[], options?: ReporterOptions): string;
+  function reporter(files: VFile[], options?: ReporterOptions): string;
+
+  export = reporter;
 }

--- a/packages/generate-persisted-query-manifest/src/@types/vfile-reporter.d.ts
+++ b/packages/generate-persisted-query-manifest/src/@types/vfile-reporter.d.ts
@@ -1,0 +1,13 @@
+declare module "vfile-reporter" {
+  import type { VFile } from "vfile";
+
+  interface ReporterOptions {
+    verbose?: boolean;
+    quiet?: boolean;
+    silent?: boolean;
+    color?: boolean;
+    defaultName?: string;
+  }
+
+  export function reporter(files: VFile[], options?: ReporterOptions): string;
+}

--- a/packages/generate-persisted-query-manifest/src/index.ts
+++ b/packages/generate-persisted-query-manifest/src/index.ts
@@ -84,17 +84,17 @@ interface DocumentSource {
 
 const errors = {
   anonymousOperation: (node: OperationDefinitionNode) => {
-    return `Anonymous GraphQL operations are not supported. Please be sure to name your ${node.operation}.`;
+    return `Anonymous GraphQL operations are not supported. Please name your ${node.operation}.`;
   },
   uniqueFragment: (name: string, source: DocumentSource) => {
     return `Fragment named "${colors.name(
       name,
-    )}" already defined in ${colors.filepath(source.file.path)}`;
+    )}" already defined in: ${colors.filepath(source.file.path)}`;
   },
   uniqueOperation: (name: string, source: DocumentSource) => {
     return `Operation named "${colors.name(
       name,
-    )}" already defined in ${colors.filepath(source.file.path)}`;
+    )}" already defined in: ${colors.filepath(source.file.path)}`;
   },
 };
 

--- a/packages/generate-persisted-query-manifest/src/index.ts
+++ b/packages/generate-persisted-query-manifest/src/index.ts
@@ -141,6 +141,8 @@ export async function generatePersistedQueryManifest(
         const sources = fragmentsByName.get(name) ?? [];
 
         fragmentsByName.set(name, [...sources, source]);
+
+        return false;
       },
       OperationDefinition(node) {
         const name = node.name?.value;
@@ -157,6 +159,8 @@ export async function generatePersistedQueryManifest(
         const sources = operationsByName.get(name) ?? [];
 
         operationsByName.set(name, [...sources, source]);
+
+        return false;
       },
     });
   }

--- a/packages/generate-persisted-query-manifest/src/index.ts
+++ b/packages/generate-persisted-query-manifest/src/index.ts
@@ -83,7 +83,7 @@ interface DocumentSource {
 }
 
 const errors = {
-  anonymous: (node: OperationDefinitionNode) => {
+  anonymousOperation: (node: OperationDefinitionNode) => {
     return `Anonymous GraphQL operations are not supported. Please be sure to name your ${node.operation}.`;
   },
   uniqueFragment: (name: string, source: DocumentSource) => {
@@ -169,7 +169,7 @@ export async function generatePersistedQueryManifest(
         const name = node.name?.value;
 
         if (!name) {
-          addError(source, errors.anonymous(node));
+          addError(source, errors.anonymousOperation(node));
 
           return false;
         }

--- a/packages/generate-persisted-query-manifest/src/index.ts
+++ b/packages/generate-persisted-query-manifest/src/index.ts
@@ -122,16 +122,12 @@ function processFile(filepath: string): DocumentSource[] {
 export async function generatePersistedQueryManifest(
   config: PersistedQueryManifestConfig = {},
 ): Promise<PersistedQueryManifest> {
-  const filePaths = new Set<string>();
   const paths = config.documents ?? defaults.documents;
   const ignorePaths =
     config.documentIgnorePatterns ?? defaults.documentIgnorePatterns;
 
-  for (const f of await glob(paths, { ignore: ignorePaths })) {
-    filePaths.add(f);
-  }
-
-  const sources = [...filePaths].flatMap(processFile);
+  const filepaths = await glob(paths, { ignore: ignorePaths });
+  const sources = [...new Set(filepaths)].flatMap(processFile);
 
   const fragmentsByName = new Map<string, DocumentSource[]>();
   const operationsByName = new Map<string, DocumentSource[]>();

--- a/packages/generate-persisted-query-manifest/src/index.ts
+++ b/packages/generate-persisted-query-manifest/src/index.ts
@@ -175,7 +175,7 @@ export async function generatePersistedQueryManifest(
         if (!name) {
           addError(source, errors.anonymous(node));
 
-          return;
+          return false;
         }
 
         const sources = operationsByName.get(name) ?? [];

--- a/packages/generate-persisted-query-manifest/src/index.ts
+++ b/packages/generate-persisted-query-manifest/src/index.ts
@@ -101,8 +101,6 @@ const errors = {
 function addError(source: DocumentSource, message: string) {
   const vfileMessage = source.file.message(message, source.location);
   vfileMessage.fatal = true;
-
-  return vfileMessage;
 }
 
 const colors = {

--- a/packages/generate-persisted-query-manifest/src/index.ts
+++ b/packages/generate-persisted-query-manifest/src/index.ts
@@ -150,7 +150,7 @@ export async function generatePersistedQueryManifest(
         if (!name) {
           error(
             source,
-            `Anonymous GraphQL operations are not supported. Make sure to name your ${node.operation}.`,
+            `Anonymous GraphQL operations are not supported. Please be sure to name your ${node.operation}.`,
           );
 
           return;

--- a/packages/generate-persisted-query-manifest/src/index.ts
+++ b/packages/generate-persisted-query-manifest/src/index.ts
@@ -114,7 +114,7 @@ function getDocumentSources(filepath: string): DocumentSource[] {
     contents: readFileSync(filepath, "utf-8"),
   });
 
-  if (file.extname === ".graphql") {
+  if (file.extname === ".graphql" || file.extname === ".gql") {
     return [
       {
         node: parse(file.toString()),

--- a/packages/generate-persisted-query-manifest/src/index.ts
+++ b/packages/generate-persisted-query-manifest/src/index.ts
@@ -94,7 +94,7 @@ const colors = {
   name: chalk.yellow,
 };
 
-function processFile(filepath: string): DocumentSource[] {
+function getDocumentSources(filepath: string): DocumentSource[] {
   const file = vfile({
     path: filepath,
     contents: readFileSync(filepath, "utf-8"),
@@ -127,7 +127,7 @@ export async function generatePersistedQueryManifest(
     config.documentIgnorePatterns ?? defaults.documentIgnorePatterns;
 
   const filepaths = await glob(paths, { ignore: ignorePaths });
-  const sources = [...new Set(filepaths)].flatMap(processFile);
+  const sources = [...new Set(filepaths)].flatMap(getDocumentSources);
 
   const fragmentsByName = new Map<string, DocumentSource[]>();
   const operationsByName = new Map<string, DocumentSource[]>();

--- a/packages/generate-persisted-query-manifest/src/index.ts
+++ b/packages/generate-persisted-query-manifest/src/index.ts
@@ -82,19 +82,24 @@ interface DocumentSource {
   location: Location;
 }
 
-const errors = {
+const COLORS = {
+  filepath: chalk.underline.cyan,
+  name: chalk.yellow,
+};
+
+const ERROR_MESSAGES = {
   anonymousOperation: (node: OperationDefinitionNode) => {
     return `Anonymous GraphQL operations are not supported. Please name your ${node.operation}.`;
   },
   uniqueFragment: (name: string, source: DocumentSource) => {
-    return `Fragment named "${colors.name(
+    return `Fragment named "${COLORS.name(
       name,
-    )}" already defined in: ${colors.filepath(source.file.path)}`;
+    )}" already defined in: ${COLORS.filepath(source.file.path)}`;
   },
   uniqueOperation: (name: string, source: DocumentSource) => {
-    return `Operation named "${colors.name(
+    return `Operation named "${COLORS.name(
       name,
-    )}" already defined in: ${colors.filepath(source.file.path)}`;
+    )}" already defined in: ${COLORS.filepath(source.file.path)}`;
   },
 };
 
@@ -102,11 +107,6 @@ function addError(source: DocumentSource, message: string) {
   const vfileMessage = source.file.message(message, source.location);
   vfileMessage.fatal = true;
 }
-
-const colors = {
-  filepath: chalk.underline.cyan,
-  name: chalk.yellow,
-};
 
 function getDocumentSources(filepath: string): DocumentSource[] {
   const file = vfile({
@@ -154,8 +154,8 @@ export async function generatePersistedQueryManifest(
 
         if (sources.length) {
           sources.forEach((sibling) => {
-            addError(source, errors.uniqueFragment(name, sibling));
-            addError(sibling, errors.uniqueFragment(name, source));
+            addError(source, ERROR_MESSAGES.uniqueFragment(name, sibling));
+            addError(sibling, ERROR_MESSAGES.uniqueFragment(name, source));
           });
         }
 
@@ -167,7 +167,7 @@ export async function generatePersistedQueryManifest(
         const name = node.name?.value;
 
         if (!name) {
-          addError(source, errors.anonymousOperation(node));
+          addError(source, ERROR_MESSAGES.anonymousOperation(node));
 
           return false;
         }
@@ -176,8 +176,8 @@ export async function generatePersistedQueryManifest(
 
         if (sources.length) {
           sources.forEach((sibling) => {
-            addError(source, errors.uniqueOperation(name, sibling));
-            addError(sibling, errors.uniqueOperation(name, source));
+            addError(source, ERROR_MESSAGES.uniqueOperation(name, sibling));
+            addError(sibling, ERROR_MESSAGES.uniqueOperation(name, source));
           });
         }
 

--- a/packages/generate-persisted-query-manifest/src/index.ts
+++ b/packages/generate-persisted-query-manifest/src/index.ts
@@ -201,7 +201,7 @@ export async function generatePersistedQueryManifest(
     }
   });
 
-  if (sources.some((document) => document.file.messages.length > 0)) {
+  if (sources.some(({ file }) => file.messages.length > 0)) {
     const files = [...new Set(sources.map((source) => source.file))];
 
     console.error(reporter(files, { quiet: true }));


### PR DESCRIPTION
Rather than erroring on the first encountered error, this PR will collect all errors up-front then report them at the same time. This also changes the format of the error to make it super clear which file the error was from.

**Before**
<img width="1210" alt="Screenshot 2023-06-09 at 6 05 38 PM" src="https://github.com/apollographql/apollo-utils/assets/565661/c7183989-5177-4ecf-be2b-f0b96571346f">

**After**
<img width="858" alt="Screenshot 2023-06-09 at 6 05 24 PM" src="https://github.com/apollographql/apollo-utils/assets/565661/7987b9a2-9f94-4fc9-b839-47c50662805a">

