### PR TITLE
Use Node 20.2 when testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ workflows:
               node-version:
                 - "16"
                 - "18"
-                - "20"
+                - "20.2"
       - GraphQL v14 - backcompat
       - GraphQL v15 - backcompat
       - Prettier


### PR DESCRIPTION
Use Node image 20.2 when testing Node 20 changes. The recently released 20.3 image seems to be [having issues](https://app.circleci.com/pipelines/github/apollographql/apollo-utils/1009/workflows/975175be-d311-4e3b-81b6-b67bfb32e847/jobs/5955) when trying to build packages via `tsc`.