### PR TITLE
Conslidate verification failure callbacks in `createPersistedQueryManifestVerificationLink` to single `onFailedVerfication` callback

### DIFF
--- a/.changeset/strong-eyes-play.md
+++ b/.changeset/strong-eyes-play.md
@@ -1,0 +1,20 @@
+---
+"@apollo/persisted-query-lists": patch
+---
+
+**`createPersistedQueryManifestVerificationLink`**
+
+- Consolidate the callbacks to a single `onVerificationFailed` callback with a `reason` property that describes the verification failure. 
+- The full `operation` is now available as a property to the `onVerificationFailed` callback.
+
+```ts
+createPersistedQueryManifestVerificationLink({
+  onVerificationFailed(details) {
+    // The reason the verification failed, such as an anonymous operation
+    console.log(details.reason)
+
+    // The operation that caused the verification failure
+    console.log(details.operation)
+  }
+})
+```

--- a/packages/persisted-query-lists/src/__tests__/persistedQueryLists.test.ts
+++ b/packages/persisted-query-lists/src/__tests__/persistedQueryLists.test.ts
@@ -279,7 +279,7 @@ describe("persisted-query-lists", () => {
         });
       });
 
-      it("different body", async () => {
+      it("operation mismatch", async () => {
         const onVerificationFailed = jest.fn();
 
         await runAgainstLink(
@@ -289,7 +289,7 @@ describe("persisted-query-lists", () => {
 
         expect(onVerificationFailed).toHaveBeenCalledTimes(1);
         expect(onVerificationFailed).toHaveBeenCalledWith({
-          reason: "QueryMismatch",
+          reason: "OperationMismatch",
           operation: createOperation({ query: "query Foobar { different }" }),
           manifestOperation: {
             id: "foobar-id",

--- a/packages/persisted-query-lists/src/__tests__/persistedQueryLists.test.ts
+++ b/packages/persisted-query-lists/src/__tests__/persistedQueryLists.test.ts
@@ -214,7 +214,7 @@ describe("persisted-query-lists", () => {
             {
               id: "foobar-id",
               name: "Foobar",
-              type: "query",
+              type: "query" as const,
               body: "query Foobar {\n  f\n}",
             },
           ],
@@ -291,7 +291,12 @@ describe("persisted-query-lists", () => {
         expect(onVerificationFailed).toHaveBeenCalledWith({
           reason: "QueryMismatch",
           operation: createOperation({ query: "query Foobar { different }" }),
-          manifestDefinition: print(parse("query Foobar {\n  f\n}")),
+          manifestOperation: {
+            id: "foobar-id",
+            name: "Foobar",
+            type: "query" as const,
+            body: "query Foobar {\n  f\n}",
+          },
         });
       });
 

--- a/packages/persisted-query-lists/src/__tests__/persistedQueryLists.test.ts
+++ b/packages/persisted-query-lists/src/__tests__/persistedQueryLists.test.ts
@@ -218,141 +218,62 @@ describe("persisted-query-lists", () => {
       }
 
       it("anonymous operation", async () => {
-        const onAnonymousOperation = jest.fn();
-        const onMultiOperationDocument = jest.fn();
-        const onNoOperationsDocument = jest.fn();
-        const onUnknownOperationName = jest.fn();
-        const onDifferentBody = jest.fn();
-        await runAgainstLink(
-          {
-            onAnonymousOperation,
-            onMultiOperationDocument,
-            onNoOperationsDocument,
-            onUnknownOperationName,
-            onDifferentBody,
-          },
-          "{ x }",
-        );
-        expect(onAnonymousOperation).toHaveBeenCalled();
-        expect(onMultiOperationDocument).not.toHaveBeenCalled();
-        expect(onNoOperationsDocument).not.toHaveBeenCalled();
-        expect(onUnknownOperationName).not.toHaveBeenCalled();
-        expect(onDifferentBody).not.toHaveBeenCalled();
+        const onError = jest.fn();
+        await runAgainstLink({ onError }, "{ x }");
+        expect(onError).toHaveBeenCalledTimes(1);
+        expect(onError).toHaveBeenCalledWith({
+          reason: "ANONYMOUS_OPERATION",
+          body: print(parse("{ x }")),
+        });
       });
 
       it("multi-operation document", async () => {
-        const onAnonymousOperation = jest.fn();
-        const onMultiOperationDocument = jest.fn();
-        const onNoOperationsDocument = jest.fn();
-        const onUnknownOperationName = jest.fn();
-        const onDifferentBody = jest.fn();
-        await runAgainstLink(
-          {
-            onAnonymousOperation,
-            onMultiOperationDocument,
-            onNoOperationsDocument,
-            onUnknownOperationName,
-            onDifferentBody,
-          },
-          "query Q { a } query QQ { b }",
-        );
-        expect(onAnonymousOperation).not.toHaveBeenCalled();
-        expect(onMultiOperationDocument).toHaveBeenCalled();
-        expect(onNoOperationsDocument).not.toHaveBeenCalled();
-        expect(onUnknownOperationName).not.toHaveBeenCalled();
-        expect(onDifferentBody).not.toHaveBeenCalled();
+        const onError = jest.fn();
+        await runAgainstLink({ onError }, "query Q { a } query QQ { b }");
+        expect(onError).toHaveBeenCalledTimes(1);
+        expect(onError).toHaveBeenCalledWith({
+          reason: "MULTI_OPERATION_DOCUMENT",
+          body: print(parse("query Q { a } query QQ { b }")),
+        });
       });
 
       it("no-operations document", async () => {
-        const onAnonymousOperation = jest.fn();
-        const onMultiOperationDocument = jest.fn();
-        const onNoOperationsDocument = jest.fn();
-        const onUnknownOperationName = jest.fn();
-        const onDifferentBody = jest.fn();
-        await runAgainstLink(
-          {
-            onAnonymousOperation,
-            onMultiOperationDocument,
-            onNoOperationsDocument,
-            onUnknownOperationName,
-            onDifferentBody,
-          },
-          "fragment F on T { f }",
-        );
-        expect(onAnonymousOperation).not.toHaveBeenCalled();
-        expect(onMultiOperationDocument).not.toHaveBeenCalled();
-        expect(onNoOperationsDocument).toHaveBeenCalled();
-        expect(onUnknownOperationName).not.toHaveBeenCalled();
-        expect(onDifferentBody).not.toHaveBeenCalled();
+        const onError = jest.fn();
+        await runAgainstLink({ onError }, "fragment F on T { f }");
+        expect(onError).toHaveBeenCalledTimes(1);
+        expect(onError).toHaveBeenCalledWith({
+          reason: "NO_OPERATIONS_DOCUMENT",
+          body: print(parse("fragment F on T { f }")),
+        });
       });
 
       it("unknown operation name", async () => {
-        const onAnonymousOperation = jest.fn();
-        const onMultiOperationDocument = jest.fn();
-        const onNoOperationsDocument = jest.fn();
-        const onUnknownOperationName = jest.fn();
-        const onDifferentBody = jest.fn();
-        await runAgainstLink(
-          {
-            onAnonymousOperation,
-            onMultiOperationDocument,
-            onNoOperationsDocument,
-            onUnknownOperationName,
-            onDifferentBody,
-          },
-          "query Foo { f }",
-        );
-        expect(onAnonymousOperation).not.toHaveBeenCalled();
-        expect(onMultiOperationDocument).not.toHaveBeenCalled();
-        expect(onNoOperationsDocument).not.toHaveBeenCalled();
-        expect(onUnknownOperationName).toHaveBeenCalled();
-        expect(onDifferentBody).not.toHaveBeenCalled();
+        const onError = jest.fn();
+        await runAgainstLink({ onError }, "query Foo { f }");
+        expect(onError).toHaveBeenCalledTimes(1);
+        expect(onError).toHaveBeenCalledWith({
+          reason: "UNKNOWN_OPERATION_NAME",
+          operationName: "Foo",
+          body: print(parse("query Foo { f }")),
+        });
       });
 
       it("different body", async () => {
-        const onAnonymousOperation = jest.fn();
-        const onMultiOperationDocument = jest.fn();
-        const onNoOperationsDocument = jest.fn();
-        const onUnknownOperationName = jest.fn();
-        const onDifferentBody = jest.fn();
-        await runAgainstLink(
-          {
-            onAnonymousOperation,
-            onMultiOperationDocument,
-            onNoOperationsDocument,
-            onUnknownOperationName,
-            onDifferentBody,
-          },
-          "query Foobar { different }",
-        );
-        expect(onAnonymousOperation).not.toHaveBeenCalled();
-        expect(onMultiOperationDocument).not.toHaveBeenCalled();
-        expect(onNoOperationsDocument).not.toHaveBeenCalled();
-        expect(onUnknownOperationName).not.toHaveBeenCalled();
-        expect(onDifferentBody).toHaveBeenCalled();
+        const onError = jest.fn();
+        await runAgainstLink({ onError }, "query Foobar { different }");
+        expect(onError).toHaveBeenCalledTimes(1);
+        expect(onError).toHaveBeenCalledWith({
+          reason: "DIFFERENT_BODY",
+          operationName: "Foobar",
+          manifestBody: print(parse("query Foobar {\n  f\n}")),
+          actualBody: print(parse("query Foobar { different }")),
+        });
       });
 
       it("operation on the manifest", async () => {
-        const onAnonymousOperation = jest.fn();
-        const onMultiOperationDocument = jest.fn();
-        const onNoOperationsDocument = jest.fn();
-        const onUnknownOperationName = jest.fn();
-        const onDifferentBody = jest.fn();
-        await runAgainstLink(
-          {
-            onAnonymousOperation,
-            onMultiOperationDocument,
-            onNoOperationsDocument,
-            onUnknownOperationName,
-            onDifferentBody,
-          },
-          "query Foobar {\n  f\n}",
-        );
-        expect(onAnonymousOperation).not.toHaveBeenCalled();
-        expect(onMultiOperationDocument).not.toHaveBeenCalled();
-        expect(onNoOperationsDocument).not.toHaveBeenCalled();
-        expect(onUnknownOperationName).not.toHaveBeenCalled();
-        expect(onDifferentBody).not.toHaveBeenCalled();
+        const onError = jest.fn();
+        await runAgainstLink({ onError }, "query Foobar {\n  f\n}");
+        expect(onError).not.toHaveBeenCalled();
       });
     });
 

--- a/packages/persisted-query-lists/src/__tests__/persistedQueryLists.test.ts
+++ b/packages/persisted-query-lists/src/__tests__/persistedQueryLists.test.ts
@@ -229,50 +229,66 @@ describe("persisted-query-lists", () => {
       }
 
       it("anonymous operation", async () => {
-        const onError = jest.fn();
-        await runAgainstLink({ onError }, "{ x }");
-        expect(onError).toHaveBeenCalledTimes(1);
-        expect(onError).toHaveBeenCalledWith({
+        const onVerificationFailed = jest.fn();
+
+        await runAgainstLink({ onVerificationFailed }, "{ x }");
+
+        expect(onVerificationFailed).toHaveBeenCalledTimes(1);
+        expect(onVerificationFailed).toHaveBeenCalledWith({
           reason: "AnonymousOperation",
           operation: createOperation({ query: "{ x }" }),
         });
       });
 
       it("multi-operation document", async () => {
-        const onError = jest.fn();
-        await runAgainstLink({ onError }, "query Q { a } query QQ { b }");
-        expect(onError).toHaveBeenCalledTimes(1);
-        expect(onError).toHaveBeenCalledWith({
+        const onVerificationFailed = jest.fn();
+
+        await runAgainstLink(
+          { onVerificationFailed },
+          "query Q { a } query QQ { b }",
+        );
+
+        expect(onVerificationFailed).toHaveBeenCalledTimes(1);
+        expect(onVerificationFailed).toHaveBeenCalledWith({
           reason: "MultipleOperations",
           operation: createOperation({ query: "query Q { a } query QQ { b }" }),
         });
       });
 
       it("no-operations document", async () => {
-        const onError = jest.fn();
-        await runAgainstLink({ onError }, "fragment F on T { f }");
-        expect(onError).toHaveBeenCalledTimes(1);
-        expect(onError).toHaveBeenCalledWith({
+        const onVerificationFailed = jest.fn();
+
+        await runAgainstLink({ onVerificationFailed }, "fragment F on T { f }");
+
+        expect(onVerificationFailed).toHaveBeenCalledTimes(1);
+        expect(onVerificationFailed).toHaveBeenCalledWith({
           reason: "NoOperations",
           operation: createOperation({ query: "fragment F on T { f }" }),
         });
       });
 
       it("unknown operation name", async () => {
-        const onError = jest.fn();
-        await runAgainstLink({ onError }, "query Foo { f }");
-        expect(onError).toHaveBeenCalledTimes(1);
-        expect(onError).toHaveBeenCalledWith({
+        const onVerificationFailed = jest.fn();
+
+        await runAgainstLink({ onVerificationFailed }, "query Foo { f }");
+
+        expect(onVerificationFailed).toHaveBeenCalledTimes(1);
+        expect(onVerificationFailed).toHaveBeenCalledWith({
           reason: "UnknownOperation",
           operation: createOperation({ query: "query Foo { f }" }),
         });
       });
 
       it("different body", async () => {
-        const onError = jest.fn();
-        await runAgainstLink({ onError }, "query Foobar { different }");
-        expect(onError).toHaveBeenCalledTimes(1);
-        expect(onError).toHaveBeenCalledWith({
+        const onVerificationFailed = jest.fn();
+
+        await runAgainstLink(
+          { onVerificationFailed },
+          "query Foobar { different }",
+        );
+
+        expect(onVerificationFailed).toHaveBeenCalledTimes(1);
+        expect(onVerificationFailed).toHaveBeenCalledWith({
           reason: "QueryMismatch",
           operation: createOperation({ query: "query Foobar { different }" }),
           manifestDefinition: print(parse("query Foobar {\n  f\n}")),
@@ -280,9 +296,14 @@ describe("persisted-query-lists", () => {
       });
 
       it("operation on the manifest", async () => {
-        const onError = jest.fn();
-        await runAgainstLink({ onError }, "query Foobar {\n  f\n}");
-        expect(onError).not.toHaveBeenCalled();
+        const onVerificationFailed = jest.fn();
+
+        await runAgainstLink(
+          { onVerificationFailed },
+          "query Foobar {\n  f\n}",
+        );
+
+        expect(onVerificationFailed).not.toHaveBeenCalled();
       });
     });
 

--- a/packages/persisted-query-lists/src/__tests__/persistedQueryLists.test.ts
+++ b/packages/persisted-query-lists/src/__tests__/persistedQueryLists.test.ts
@@ -222,8 +222,8 @@ describe("persisted-query-lists", () => {
         await runAgainstLink({ onError }, "{ x }");
         expect(onError).toHaveBeenCalledTimes(1);
         expect(onError).toHaveBeenCalledWith({
-          reason: "ANONYMOUS_OPERATION",
-          body: print(parse("{ x }")),
+          reason: "AnonymousOperation",
+          query: print(parse("{ x }")),
         });
       });
 
@@ -232,8 +232,8 @@ describe("persisted-query-lists", () => {
         await runAgainstLink({ onError }, "query Q { a } query QQ { b }");
         expect(onError).toHaveBeenCalledTimes(1);
         expect(onError).toHaveBeenCalledWith({
-          reason: "MULTI_OPERATION_DOCUMENT",
-          body: print(parse("query Q { a } query QQ { b }")),
+          reason: "MultipleOperations",
+          query: print(parse("query Q { a } query QQ { b }")),
         });
       });
 
@@ -242,8 +242,8 @@ describe("persisted-query-lists", () => {
         await runAgainstLink({ onError }, "fragment F on T { f }");
         expect(onError).toHaveBeenCalledTimes(1);
         expect(onError).toHaveBeenCalledWith({
-          reason: "NO_OPERATIONS_DOCUMENT",
-          body: print(parse("fragment F on T { f }")),
+          reason: "NoOperations",
+          query: print(parse("fragment F on T { f }")),
         });
       });
 
@@ -252,9 +252,9 @@ describe("persisted-query-lists", () => {
         await runAgainstLink({ onError }, "query Foo { f }");
         expect(onError).toHaveBeenCalledTimes(1);
         expect(onError).toHaveBeenCalledWith({
-          reason: "UNKNOWN_OPERATION_NAME",
+          reason: "UnknownOperation",
           operationName: "Foo",
-          body: print(parse("query Foo { f }")),
+          query: print(parse("query Foo { f }")),
         });
       });
 
@@ -263,10 +263,10 @@ describe("persisted-query-lists", () => {
         await runAgainstLink({ onError }, "query Foobar { different }");
         expect(onError).toHaveBeenCalledTimes(1);
         expect(onError).toHaveBeenCalledWith({
-          reason: "DIFFERENT_BODY",
+          reason: "QueryMismatch",
           operationName: "Foobar",
-          manifestBody: print(parse("query Foobar {\n  f\n}")),
-          actualBody: print(parse("query Foobar { different }")),
+          manifestDefinition: print(parse("query Foobar {\n  f\n}")),
+          query: print(parse("query Foobar { different }")),
         });
       });
 

--- a/packages/persisted-query-lists/src/index.ts
+++ b/packages/persisted-query-lists/src/index.ts
@@ -159,7 +159,7 @@ type PersistedQueryManifestVerificationLinkErrorDetails =
   | { reason: "NoOperations"; operation: Operation }
   | { reason: "UnknownOperation"; operation: Operation }
   | {
-      reason: "QueryMismatch";
+      reason: "OperationMismatch";
       operation: Operation;
       manifestOperation: PersistedQueryManifestOperation;
     };
@@ -237,7 +237,7 @@ export function createPersistedQueryManifestVerificationLink(
 
     if (query !== manifestOperation.body) {
       options.onVerificationFailed?.({
-        reason: "QueryMismatch",
+        reason: "OperationMismatch",
         operation,
         manifestOperation,
       });

--- a/packages/persisted-query-lists/src/index.ts
+++ b/packages/persisted-query-lists/src/index.ts
@@ -168,7 +168,7 @@ export interface CreatePersistedQueryManifestVerificationLinkOptions {
   // is created, not on the first operation: it's an async load, not a lazy
   // load.
   loadManifest: () => Promise<PersistedQueryManifestForVerification>;
-  onError?: (
+  onVerificationFailed?: (
     details: PersistedQueryManifestVerificationLinkErrorDetails,
   ) => void;
 }
@@ -202,23 +202,29 @@ export function createPersistedQueryManifestVerificationLink(
     for (const definition of operation.query.definitions) {
       if (definition.kind === "OperationDefinition") {
         if (!definition.name) {
-          options.onError?.({ reason: "AnonymousOperation", operation });
+          options.onVerificationFailed?.({
+            reason: "AnonymousOperation",
+            operation,
+          });
           return;
         }
         if (operationName !== null) {
-          options.onError?.({ reason: "MultipleOperations", operation });
+          options.onVerificationFailed?.({
+            reason: "MultipleOperations",
+            operation,
+          });
           return;
         }
         operationName = definition.name.value;
       }
     }
     if (operationName === null) {
-      options.onError?.({ reason: "NoOperations", operation });
+      options.onVerificationFailed?.({ reason: "NoOperations", operation });
       return;
     }
     const manifestDefinition = operationBodiesByName.get(operationName);
     if (manifestDefinition === undefined) {
-      options.onError?.({
+      options.onVerificationFailed?.({
         reason: "UnknownOperation",
         operation,
       });
@@ -226,7 +232,7 @@ export function createPersistedQueryManifestVerificationLink(
     }
 
     if (query !== manifestDefinition) {
-      options.onError?.({
+      options.onVerificationFailed?.({
         reason: "QueryMismatch",
         operation,
         manifestDefinition,

--- a/packages/persisted-query-lists/src/index.ts
+++ b/packages/persisted-query-lists/src/index.ts
@@ -1,6 +1,6 @@
 import { print, type DocumentNode } from "graphql";
 import { ApolloLink } from "@apollo/client/link/core";
-import { Observable, ObservableSubscription } from "@apollo/client/core";
+import { Observable, type ObservableSubscription } from "@apollo/client/core";
 
 // This type is copied from `@apollo/client/link/persisted-queries`; to avoid a
 // dependency on a particular version `@apollo/client` we copy it here.

--- a/packages/persisted-query-lists/src/index.ts
+++ b/packages/persisted-query-lists/src/index.ts
@@ -192,7 +192,7 @@ export function createPersistedQueryManifestVerificationLink(
   // still throw.
   operationBodiesByNamePromise.catch(() => {});
 
-  function checkOperation(
+  function verifyOperation(
     operation: Operation,
     operationBodiesByName: Map<string, string>,
   ) {
@@ -248,7 +248,7 @@ export function createPersistedQueryManifestVerificationLink(
       let closed = false;
       operationBodiesByNamePromise
         .then((operationBodiesByName) => {
-          checkOperation(operation, operationBodiesByName);
+          verifyOperation(operation, operationBodiesByName);
 
           // if the observer is already closed, no need to subscribe.
           if (closed) return;


### PR DESCRIPTION
The `createPersistedQueryManifestVerificationLink` previously took several options for handling failed verifications:

- `onAnonymousOperation`
- `onMultiOperationDocument`
- `onNoOperationsDocument`
- `onUnknownOperationName`
- `onDifferentBody`

While this worked, this creates a large burden on the developer to remember to add a callback for each callback or risk missing some notifications. Adding additional checks in the future also means additional callbacks.

Instead, this PR conslidates the failures down to a single `onVerificationFailed` handler with a `reason` field that describes the verification that failed.