### PR TITLE
Add ability create custom manifest operation IDs

### DIFF
--- a/.changeset/twenty-ligers-sip.md
+++ b/.changeset/twenty-ligers-sip.md
@@ -1,0 +1,24 @@
+---
+"@apollo/generate-persisted-query-manifest": patch
+---
+
+Add the ability to create custom manifest operation IDs by defining a `createCustomId` function in the config file.
+
+```ts
+// persisted-query-manifest.config.ts
+import { PersistedQueryManifestConfig } from '@apollo/generate-persisted-query-manifest';
+import { Buffer } from 'node:buffer'
+
+const config: PersistedQueryManifestConfig = {
+  createOperationId(query, { operationName, createDefaultId }) {
+    switch (operationName) {
+      case 'TestOperation':
+        return Buffer.from(query).toString('base64');
+      default:
+        return createDefaultId();
+    }
+  }
+}
+
+export default config;
+```

--- a/packages/generate-persisted-query-manifest/cli.js
+++ b/packages/generate-persisted-query-manifest/cli.js
@@ -37,7 +37,10 @@ program
     const result = await getUserConfig(cliOptions);
     const outputPath = result?.config.output ?? defaults.output;
 
-    const manifest = await generatePersistedQueryManifest(result?.config);
+    const manifest = await generatePersistedQueryManifest(
+      result?.config,
+      result?.filepath,
+    );
     writeFileSync(outputPath, JSON.stringify(manifest, null, 2));
 
     console.log(`Manifest written to ${outputPath}`);

--- a/packages/generate-persisted-query-manifest/src/index.ts
+++ b/packages/generate-persisted-query-manifest/src/index.ts
@@ -132,7 +132,10 @@ const ERROR_MESSAGES = {
   },
 };
 
-function addError(source: DocumentSource, message: string) {
+function addError(
+  source: Pick<DocumentSource, "file"> & Partial<DocumentSource>,
+  message: string,
+) {
   const vfileMessage = source.file.message(message, source.location);
   vfileMessage.fatal = true;
 }
@@ -275,14 +278,14 @@ export async function generatePersistedQueryManifest(
       // a config file, our default id function will be used which is
       // guaranteed to create unique IDs.
       if (manifestOperationIds.has(id)) {
-        const message = configFile.message(
+        addError(
+          { file: configFile },
           ERROR_MESSAGES.uniqueOperationId(
             id,
             name,
             manifestOperationIds.get(id)!,
           ),
         );
-        message.fatal = true;
       } else {
         manifestOperationIds.set(id, name);
       }

--- a/packages/generate-persisted-query-manifest/src/index.ts
+++ b/packages/generate-persisted-query-manifest/src/index.ts
@@ -146,13 +146,13 @@ function getDocumentSources(filepath: string): DocumentSource[] {
 export async function generatePersistedQueryManifest(
   config: PersistedQueryManifestConfig = {},
 ): Promise<PersistedQueryManifest> {
-  const { createOperationId = defaults.createOperationId } = config;
+  const {
+    documents = defaults.documents,
+    documentIgnorePatterns = defaults.documentIgnorePatterns,
+    createOperationId = defaults.createOperationId,
+  } = config;
 
-  const paths = config.documents ?? defaults.documents;
-  const ignorePaths =
-    config.documentIgnorePatterns ?? defaults.documentIgnorePatterns;
-
-  const filepaths = await glob(paths, { ignore: ignorePaths });
+  const filepaths = await glob(documents, { ignore: documentIgnorePatterns });
   const sources = [...new Set(filepaths)].flatMap(getDocumentSources);
 
   const fragmentsByName = new Map<string, DocumentSource[]>();

--- a/packages/generate-persisted-query-manifest/src/index.ts
+++ b/packages/generate-persisted-query-manifest/src/index.ts
@@ -23,8 +23,6 @@ import type { VFile } from "vfile";
 import reporter from "vfile-reporter";
 import chalk from "chalk";
 
-type RequireKeys<T, K extends keyof T> = Required<Pick<T, K>> & Omit<T, K>;
-
 type OperationType = "query" | "mutation" | "subscription";
 
 interface CreateOperationIdOptions {
@@ -59,11 +57,6 @@ export interface PersistedQueryManifestConfig {
   ) => string;
 }
 
-type DefaultPersistedQueryManifestConfig = RequireKeys<
-  PersistedQueryManifestConfig,
-  "documents" | "documentIgnorePatterns" | "output" | "createOperationId"
->;
-
 export interface PersistedQueryManifestOperation {
   id: string;
   name: string;
@@ -77,7 +70,7 @@ export interface PersistedQueryManifest {
   operations: PersistedQueryManifestOperation[];
 }
 
-export const defaults: DefaultPersistedQueryManifestConfig = {
+export const defaults = {
   documents: "src/**/*.{graphql,gql,js,jsx,ts,tsx}",
   documentIgnorePatterns: [
     "**/*.d.ts",
@@ -86,7 +79,7 @@ export const defaults: DefaultPersistedQueryManifestConfig = {
     "**/*.test.{js,jsx,ts,tsx}",
   ],
   output: "persisted-query-manifest.json",
-  createOperationId: (query) => {
+  createOperationId: (query: string) => {
     return createHash("sha256").update(query).digest("hex");
   },
 };

--- a/packages/generate-persisted-query-manifest/src/index.ts
+++ b/packages/generate-persisted-query-manifest/src/index.ts
@@ -122,11 +122,11 @@ const ERROR_MESSAGES = {
     operationName: string,
     definedOperationName: string,
   ) => {
-    return `Manifest operation ID (${COLORS.identifier(
+    return `\`createOperationId\` created an ID (${COLORS.identifier(
       id,
     )}) for operation named "${COLORS.name(
       operationName,
-    )}" has already been defined for operation named "${COLORS.name(
+    )}" that has already been used for operation named "${COLORS.name(
       definedOperationName,
     )}".`;
   },

--- a/packages/generate-persisted-query-manifest/src/index.ts
+++ b/packages/generate-persisted-query-manifest/src/index.ts
@@ -187,9 +187,11 @@ export async function generatePersistedQueryManifest(
     createOperationId = defaults.createOperationId,
   } = config;
 
-  const configFile = configFilePath
-    ? vfile({ path: relative(process.cwd(), configFilePath) })
-    : null;
+  const configFile = vfile({
+    path: configFilePath
+      ? relative(process.cwd(), configFilePath)
+      : "<virtual>",
+  });
   const filepaths = await glob(documents, { ignore: documentIgnorePatterns });
   const sources = uniq(filepaths).flatMap(getDocumentSources);
 
@@ -272,7 +274,7 @@ export async function generatePersistedQueryManifest(
       // We only need to validate the `id` when using a config file. Without
       // a config file, our default id function will be used which is
       // guaranteed to create unique IDs.
-      if (configFile && manifestOperationIds.has(id)) {
+      if (manifestOperationIds.has(id)) {
         const message = configFile.message(
           ERROR_MESSAGES.uniqueOperationId(
             id,
@@ -297,9 +299,7 @@ export async function generatePersistedQueryManifest(
     }
   }
 
-  if (configFile) {
-    maybeReportErrorsAndExit(configFile);
-  }
+  maybeReportErrorsAndExit(configFile);
 
   return {
     format: "apollo-persisted-query-manifest",

--- a/packages/generate-persisted-query-manifest/src/index.ts
+++ b/packages/generate-persisted-query-manifest/src/index.ts
@@ -28,6 +28,7 @@ type OperationType = "query" | "mutation" | "subscription";
 interface CreateOperationIdOptions {
   operationName: string;
   type: OperationType;
+  createDefaultId: () => string;
 }
 
 export interface PersistedQueryManifestConfig {
@@ -231,7 +232,13 @@ export async function generatePersistedQueryManifest(
       ).operation;
 
       manifestOperations.push({
-        id: createOperationId(body, { operationName: name, type }),
+        id: createOperationId(body, {
+          operationName: name,
+          type,
+          createDefaultId() {
+            return defaults.createOperationId(body);
+          },
+        }),
         name,
         type,
         body,


### PR DESCRIPTION
The `generate-persisted-query-manifest` CLI now has the ability to generate custom manifest operation IDs. When using a config file format that supports functions (i.e. `js` and `ts` extensions), a `createCustomId` function can be added to customize how the ID should be generated for a given query.

Here is an example that shows how to create a base64 encoded ID of the query when its operation name is `TestOperation`:

```ts
// persisted-query-manifest.config.ts
import { PersistedQueryManifestConfig } from '@apollo/generate-persisted-query-manifest';
import { Buffer } from 'node:buffer'

const config: PersistedQueryManifestConfig = {
  createOperationId(query, { operationName, createDefaultId }) {
    switch (operationName) {
      case 'TestOperation':
        return Buffer.from(query).toString('base64');
      default:
        return createDefaultId();
    }
  }
}

export default config;
```

The `id` returned from `createOperationId` will be validated for uniqueness before the manifest file is written.
<img width="1479" alt="Screenshot 2023-06-14 at 1 16 10 AM" src="https://github.com/apollographql/apollo-utils/assets/565661/1e749037-6adb-4672-8901-8d4f412d5df3">



---

The `createOperationId` function signature is as-follows:

```ts
createOperationId(query: string, options: CreateOperationIdOptions) => string

type CreateOperationIdOptions {
  operationName: string;
  type: OperationType;
  createDefaultId: () => string;
}
```