### PR TITLE
Allow persisted query manifest to be loaded synchronously

### DIFF
--- a/packages/persisted-query-lists/src/__tests__/persistedQueryLists.test.ts
+++ b/packages/persisted-query-lists/src/__tests__/persistedQueryLists.test.ts
@@ -158,6 +158,48 @@ describe("persisted-query-lists", () => {
         toPromise(execute(link, { query: parse("{__typename}") })),
       ).rejects.toThrow("nope");
     });
+
+    it("allows manifest to be loaded synchronously", async () => {
+      const manifest = {
+        format: "apollo-persisted-query-manifest",
+        version: 1,
+        operations: [
+          {
+            id: "foobar-id",
+            name: "Foobar",
+            type: "query",
+            body: "query Foobar { f }",
+          },
+        ],
+      };
+
+      const link = createPersistedQueryLink(
+        generatePersistedQueryIdsFromManifest({
+          loadManifest: () => manifest,
+        }),
+      ).concat(returnExtensionsAndContextLink);
+
+      expect(
+        await toPromise(execute(link, { query: parse("query Foobar { f }") })),
+      ).toMatchInlineSnapshot(`
+        {
+          "data": {
+            "context": {
+              "http": {
+                "includeExtensions": true,
+                "includeQuery": false,
+              },
+            },
+            "extensions": {
+              "persistedQuery": {
+                "sha256Hash": "foobar-id",
+                "version": 1,
+              },
+            },
+          },
+        }
+      `);
+    });
   });
 
   describe("sortTopLevelDefinitions", () => {

--- a/packages/persisted-query-lists/src/__tests__/persistedQueryLists.test.ts
+++ b/packages/persisted-query-lists/src/__tests__/persistedQueryLists.test.ts
@@ -352,6 +352,34 @@ describe("persisted-query-lists", () => {
 
         expect(onVerificationFailed).not.toHaveBeenCalled();
       });
+
+      it("allows manifest to be loaded synchronously", async () => {
+        const manifest = {
+          format: "apollo-persisted-query-manifest",
+          version: 1,
+          operations: [
+            {
+              id: "foobar-id",
+              name: "Foobar",
+              type: "query" as const,
+              body: "query Foobar {\n  f\n}",
+            },
+          ],
+        };
+
+        const onVerificationFailed = jest.fn();
+
+        const link = createPersistedQueryManifestVerificationLink({
+          loadManifest: () => manifest,
+          onVerificationFailed,
+        }).concat(returnExtensionsAndContextLink);
+
+        await toPromise(
+          execute(link, { query: parse("query Foobar {\n  f\n}") }),
+        );
+
+        expect(onVerificationFailed).not.toHaveBeenCalled();
+      });
     });
 
     it("error loading manifest", async () => {

--- a/packages/persisted-query-lists/src/index.ts
+++ b/packages/persisted-query-lists/src/index.ts
@@ -175,7 +175,9 @@ export interface CreatePersistedQueryManifestVerificationLinkOptions {
   // manifest out of the bundle.) This function is invoked as soon as the link
   // is created, not on the first operation: it's an async load, not a lazy
   // load.
-  loadManifest: () => Promise<PersistedQueryManifestForVerification>;
+  loadManifest: () =>
+    | Promise<PersistedQueryManifestForVerification>
+    | PersistedQueryManifestForVerification;
   onVerificationFailed?: (
     details: PersistedQueryManifestVerificationLinkErrorDetails,
   ) => void;
@@ -183,15 +185,20 @@ export interface CreatePersistedQueryManifestVerificationLinkOptions {
 export function createPersistedQueryManifestVerificationLink(
   options: CreatePersistedQueryManifestVerificationLinkOptions,
 ) {
-  const operationsByNamePromise = options.loadManifest().then((manifest) => {
-    const operationsByName = new Map<string, PersistedQueryManifestOperation>();
+  const operationsByNamePromise = Promise.resolve(options.loadManifest()).then(
+    (manifest) => {
+      const operationsByName = new Map<
+        string,
+        PersistedQueryManifestOperation
+      >();
 
-    manifest.operations.forEach((operation) => {
-      operationsByName.set(operation.name, operation);
-    });
+      manifest.operations.forEach((operation) => {
+        operationsByName.set(operation.name, operation);
+      });
 
-    return operationsByName;
-  });
+      return operationsByName;
+    },
+  );
   // If the load fails before the first time we try to run an operation, we
   // don't want the JS environment to chide us for having an unhandled
   // rejection: we'll handle the rejection when we `await` below during our

--- a/packages/persisted-query-lists/src/index.ts
+++ b/packages/persisted-query-lists/src/index.ts
@@ -84,12 +84,16 @@ export interface GeneratePersistedQueryIdsFromManifestOptions {
   //  This function is invoked as soon as the link
   // is created, not on the first operation: it's an async load, not a lazy
   // load.
-  loadManifest: () => Promise<PersistedQueryManifestForGeneratingPersistedQueryIds>;
+  loadManifest: () =>
+    | Promise<PersistedQueryManifestForGeneratingPersistedQueryIds>
+    | PersistedQueryManifestForGeneratingPersistedQueryIds;
 }
 export function generatePersistedQueryIdsFromManifest(
   options: GeneratePersistedQueryIdsFromManifestOptions,
 ) {
-  const operationIdsByNamePromise = options.loadManifest().then((manifest) => {
+  const operationIdsByNamePromise = Promise.resolve(
+    options.loadManifest(),
+  ).then((manifest) => {
     const operationIdsByName = new Map<string, string>();
     manifest.operations.forEach(({ name, id }) => {
       operationIdsByName.set(name, id);


### PR DESCRIPTION
Adds the ability to load the persisted query manifest synchronously. In case someone already has the manifest loaded for other reasons, it can now be passed directly to both `createPersistedQueryManifestVerificationLink` and `generatePersistedQueryIdsFromManifest`