### PR TITLE
feat: [GH-177] Custom Cache Set Options

### DIFF
--- a/packages/keyValueCache/README.md
+++ b/packages/keyValueCache/README.md
@@ -1,9 +1,12 @@
 # KeyValueCache interface
 
 ```ts
-export interface KeyValueCache<V = string> {
+export interface KeyValueCache<
+  V = string,
+  SO extends KeyValueCacheSetOptions = KeyValueCacheSetOptions,
+> {
   get(key: string): Promise<V | undefined>;
-  set(key: string, value: V, options?: KeyValueCacheSetOptions): Promise<void>;
+  set(key: string, value: V, options?: SO): Promise<void>;
   delete(key: string): Promise<boolean | void>;
 }
 ```

--- a/packages/keyValueCache/src/ErrorsAreMissesCache.ts
+++ b/packages/keyValueCache/src/ErrorsAreMissesCache.ts
@@ -1,4 +1,4 @@
-import type { KeyValueCache } from "./KeyValueCache";
+import type { KeyValueCache, KeyValueCacheSetOptions } from "./KeyValueCache";
 import type { Logger } from "@apollo/utils.logger";
 
 /**
@@ -6,9 +6,13 @@ import type { Logger } from "@apollo/utils.logger";
  * errors thrown by the underlying cache. You can also provide a logger to
  * capture these errors rather than just swallow them.
  */
-export class ErrorsAreMissesCache<V = string> implements KeyValueCache<V> {
+export class ErrorsAreMissesCache<
+  V = string,
+  SO extends KeyValueCacheSetOptions = KeyValueCacheSetOptions,
+> implements KeyValueCache<V, SO>
+{
   constructor(
-    private cache: KeyValueCache<V>,
+    private cache: KeyValueCache<V, SO>,
     private logger?: Logger,
   ) {}
 
@@ -27,7 +31,7 @@ export class ErrorsAreMissesCache<V = string> implements KeyValueCache<V> {
     }
   }
 
-  async set(key: string, value: V, opts?: { ttl?: number }): Promise<void> {
+  async set(key: string, value: V, opts?: SO): Promise<void> {
     return this.cache.set(key, value, opts);
   }
 

--- a/packages/keyValueCache/src/InMemoryLRUCache.ts
+++ b/packages/keyValueCache/src/InMemoryLRUCache.ts
@@ -2,8 +2,10 @@ import { LRUCache } from "lru-cache";
 import type { KeyValueCache, KeyValueCacheSetOptions } from "./KeyValueCache";
 
 // LRUCache wrapper to implement the KeyValueCache interface.
-export class InMemoryLRUCache<V extends {} = string>
-  implements KeyValueCache<V>
+export class InMemoryLRUCache<
+  V extends {} = string,
+  SO extends KeyValueCacheSetOptions = KeyValueCacheSetOptions,
+> implements KeyValueCache<V, SO>
 {
   private cache: LRUCache<string, V>;
 
@@ -32,7 +34,7 @@ export class InMemoryLRUCache<V extends {} = string>
     return 1;
   }
 
-  async set(key: string, value: V, options?: KeyValueCacheSetOptions) {
+  async set(key: string, value: V, options?: SO) {
     if (options?.ttl) {
       this.cache.set(key, value, { ttl: options.ttl * 1000 });
     } else {

--- a/packages/keyValueCache/src/KeyValueCache.ts
+++ b/packages/keyValueCache/src/KeyValueCache.ts
@@ -1,6 +1,9 @@
-export interface KeyValueCache<V = string> {
+export interface KeyValueCache<
+  V = string,
+  SO extends KeyValueCacheSetOptions = KeyValueCacheSetOptions,
+> {
   get(key: string): Promise<V | undefined>;
-  set(key: string, value: V, options?: KeyValueCacheSetOptions): Promise<void>;
+  set(key: string, value: V, options?: SO): Promise<void>;
   delete(key: string): Promise<boolean | void>;
 }
 

--- a/packages/keyValueCache/src/PrefixingKeyValueCache.ts
+++ b/packages/keyValueCache/src/PrefixingKeyValueCache.ts
@@ -53,15 +53,15 @@ export class PrefixingKeyValueCache<
   // package doesn't break things).
   static prefixesAreUnnecessaryForIsolation<
     V = string,
-    O extends KeyValueCacheSetOptions = KeyValueCacheSetOptions,
-  >(c: KeyValueCache<V, O>): boolean {
+    SO extends KeyValueCacheSetOptions = KeyValueCacheSetOptions,
+  >(c: KeyValueCache<V, SO>): boolean {
     return prefixesAreUnnecessaryForIsolationSymbol in c;
   }
 
   static cacheDangerouslyDoesNotNeedPrefixesForIsolation<
     V = string,
-    O extends KeyValueCacheSetOptions = KeyValueCacheSetOptions,
-  >(c: KeyValueCache<V, O>): KeyValueCache<V, O> {
+    SO extends KeyValueCacheSetOptions = KeyValueCacheSetOptions,
+  >(c: KeyValueCache<V, SO>): KeyValueCache<V, SO> {
     return new PrefixesAreUnnecessaryForIsolationCache(c);
   }
 }
@@ -70,17 +70,17 @@ export class PrefixingKeyValueCache<
 // PrefixingKeyValueCache. See the README for details.
 class PrefixesAreUnnecessaryForIsolationCache<
   V = string,
-  O extends KeyValueCacheSetOptions = KeyValueCacheSetOptions,
-> implements KeyValueCache<V, O>
+  SO extends KeyValueCacheSetOptions = KeyValueCacheSetOptions,
+> implements KeyValueCache<V, SO>
 {
   [prefixesAreUnnecessaryForIsolationSymbol] = true;
 
-  constructor(private wrapped: KeyValueCache<V, O>) {}
+  constructor(private wrapped: KeyValueCache<V, SO>) {}
 
   get(key: string) {
     return this.wrapped.get(key);
   }
-  set(key: string, value: V, options?: O) {
+  set(key: string, value: V, options?: SO) {
     return this.wrapped.set(key, value, options);
   }
   delete(key: string) {

--- a/packages/keyValueCache/src/PrefixingKeyValueCache.ts
+++ b/packages/keyValueCache/src/PrefixingKeyValueCache.ts
@@ -16,14 +16,14 @@ const prefixesAreUnnecessaryForIsolationSymbol = Symbol(
 // trying to provide a flush() method here could be confusingly dangerous.
 export class PrefixingKeyValueCache<
   V = string,
-  O extends KeyValueCacheSetOptions = KeyValueCacheSetOptions,
-> implements KeyValueCache<V, O>
+  SO extends KeyValueCacheSetOptions = KeyValueCacheSetOptions,
+> implements KeyValueCache<V, SO>
 {
   private prefix: string;
   [prefixesAreUnnecessaryForIsolationSymbol]?: true;
 
   constructor(
-    private wrapped: KeyValueCache<V, O>,
+    private wrapped: KeyValueCache<V, SO>,
     prefix: string,
   ) {
     if (PrefixingKeyValueCache.prefixesAreUnnecessaryForIsolation(wrapped)) {
@@ -41,7 +41,7 @@ export class PrefixingKeyValueCache<
   get(key: string) {
     return this.wrapped.get(this.prefix + key);
   }
-  set(key: string, value: V, options?: O) {
+  set(key: string, value: V, options?: SO) {
     return this.wrapped.set(this.prefix + key, value, options);
   }
   delete(key: string) {

--- a/packages/keyValueCache/src/PrefixingKeyValueCache.ts
+++ b/packages/keyValueCache/src/PrefixingKeyValueCache.ts
@@ -14,12 +14,16 @@ const prefixesAreUnnecessaryForIsolationSymbol = Symbol(
 // send a simple command that wipes the entire backend cache system, which
 // wouldn't support "only wipe the part of the cache with this prefix", so
 // trying to provide a flush() method here could be confusingly dangerous.
-export class PrefixingKeyValueCache<V = string> implements KeyValueCache<V> {
+export class PrefixingKeyValueCache<
+  V = string,
+  O extends KeyValueCacheSetOptions = KeyValueCacheSetOptions,
+> implements KeyValueCache<V, O>
+{
   private prefix: string;
   [prefixesAreUnnecessaryForIsolationSymbol]?: true;
 
   constructor(
-    private wrapped: KeyValueCache<V>,
+    private wrapped: KeyValueCache<V, O>,
     prefix: string,
   ) {
     if (PrefixingKeyValueCache.prefixesAreUnnecessaryForIsolation(wrapped)) {
@@ -37,7 +41,7 @@ export class PrefixingKeyValueCache<V = string> implements KeyValueCache<V> {
   get(key: string) {
     return this.wrapped.get(this.prefix + key);
   }
-  set(key: string, value: V, options?: KeyValueCacheSetOptions) {
+  set(key: string, value: V, options?: O) {
     return this.wrapped.set(this.prefix + key, value, options);
   }
   delete(key: string) {
@@ -47,32 +51,36 @@ export class PrefixingKeyValueCache<V = string> implements KeyValueCache<V> {
   // Checks to see if a cache is a PrefixesAreUnnecessaryForIsolationCache,
   // without using instanceof (so that installing multiple copies of this
   // package doesn't break things).
-  static prefixesAreUnnecessaryForIsolation<V = string>(
-    c: KeyValueCache<V>,
-  ): boolean {
+  static prefixesAreUnnecessaryForIsolation<
+    V = string,
+    O extends KeyValueCacheSetOptions = KeyValueCacheSetOptions,
+  >(c: KeyValueCache<V, O>): boolean {
     return prefixesAreUnnecessaryForIsolationSymbol in c;
   }
 
-  static cacheDangerouslyDoesNotNeedPrefixesForIsolation<V = string>(
-    c: KeyValueCache<V>,
-  ): KeyValueCache<V> {
+  static cacheDangerouslyDoesNotNeedPrefixesForIsolation<
+    V = string,
+    O extends KeyValueCacheSetOptions = KeyValueCacheSetOptions,
+  >(c: KeyValueCache<V, O>): KeyValueCache<V, O> {
     return new PrefixesAreUnnecessaryForIsolationCache(c);
   }
 }
 
 // This class lets you opt a cache out of the prefixing provided by
 // PrefixingKeyValueCache. See the README for details.
-class PrefixesAreUnnecessaryForIsolationCache<V = string>
-  implements KeyValueCache<V>
+class PrefixesAreUnnecessaryForIsolationCache<
+  V = string,
+  O extends KeyValueCacheSetOptions = KeyValueCacheSetOptions,
+> implements KeyValueCache<V, O>
 {
   [prefixesAreUnnecessaryForIsolationSymbol] = true;
 
-  constructor(private wrapped: KeyValueCache<V>) {}
+  constructor(private wrapped: KeyValueCache<V, O>) {}
 
   get(key: string) {
     return this.wrapped.get(key);
   }
-  set(key: string, value: V, options?: KeyValueCacheSetOptions) {
+  set(key: string, value: V, options?: O) {
     return this.wrapped.set(key, value, options);
   }
   delete(key: string) {

--- a/packages/keyValueCache/src/__tests__/ErrorsAreMissesCache.test.ts
+++ b/packages/keyValueCache/src/__tests__/ErrorsAreMissesCache.test.ts
@@ -1,6 +1,11 @@
 import type { Logger } from "@apollo/utils.logger";
 import { ErrorsAreMissesCache } from "../ErrorsAreMissesCache";
-import type { KeyValueCache } from "../KeyValueCache";
+import type { KeyValueCache, KeyValueCacheSetOptions } from "../KeyValueCache";
+
+interface CustomKeyValueCacheSetOptions extends KeyValueCacheSetOptions {
+  noDisposeOnSet?: boolean;
+  noUpdateTTL?: boolean;
+}
 
 describe("ErrorsAreMissesCache", () => {
   const knownErrorMessage = "Service is down";
@@ -35,7 +40,7 @@ describe("ErrorsAreMissesCache", () => {
   });
 
   it("passes through calls to the underlying cache", async () => {
-    const mockCache: KeyValueCache = {
+    const mockCache: KeyValueCache<string, CustomKeyValueCacheSetOptions> = {
       get: jest.fn(async () => "foo"),
       set: jest.fn(),
       delete: jest.fn(),
@@ -47,9 +52,15 @@ describe("ErrorsAreMissesCache", () => {
 
     await errorsAreMisses.set("key", "foo");
     expect(mockCache.set).toHaveBeenCalledWith("key", "foo", undefined);
-    await errorsAreMisses.set("keyWithTTL", "foo", { ttl: 1000 });
-    expect(mockCache.set).toHaveBeenLastCalledWith("keyWithTTL", "foo", {
+    await errorsAreMisses.set("keyWithOptions", "foo", {
       ttl: 1000,
+      noDisposeOnSet: true,
+      noUpdateTTL: true,
+    });
+    expect(mockCache.set).toHaveBeenLastCalledWith("keyWithOptions", "foo", {
+      ttl: 1000,
+      noDisposeOnSet: true,
+      noUpdateTTL: true,
     });
 
     await errorsAreMisses.delete("key");

--- a/packages/keyValueCache/src/__tests__/PrefixingKeyValueCache.test.ts
+++ b/packages/keyValueCache/src/__tests__/PrefixingKeyValueCache.test.ts
@@ -1,5 +1,9 @@
-import { InMemoryLRUCache } from "..";
+import { InMemoryLRUCache, type KeyValueCacheSetOptions } from "..";
 import { PrefixingKeyValueCache } from "../PrefixingKeyValueCache";
+
+interface CustomKeyValueCacheSetOptions extends KeyValueCacheSetOptions {
+  tags?: string[];
+}
 
 describe("PrefixingKeyValueCache", () => {
   it("prefixes", async () => {
@@ -44,5 +48,32 @@ describe("PrefixingKeyValueCache", () => {
     expect(
       PrefixingKeyValueCache.prefixesAreUnnecessaryForIsolation(prefixing),
     ).toBe(true);
+  });
+  it("prefixes with custom extended options", async () => {
+    const inner = new InMemoryLRUCache<string, CustomKeyValueCacheSetOptions>();
+    const spyOnCacheSet = jest.spyOn(inner, "set");
+    const prefixing = new PrefixingKeyValueCache(inner, "prefix:");
+
+    await prefixing.set("key", "foo");
+    expect(spyOnCacheSet).toBeCalledWith("prefix:key", "foo", undefined);
+
+    expect(await prefixing.get("key")).toBe("foo");
+    expect(await inner.get("prefix:key")).toBe("foo");
+    await prefixing.delete("key");
+    expect(await prefixing.get("key")).toBe(undefined);
+
+    await prefixing.set("keyWithOptions", "bar", {
+      ttl: 1000,
+      tags: ["tag1", "tag2"],
+    });
+    expect(spyOnCacheSet).toBeCalledWith("prefix:keyWithOptions", "bar", {
+      ttl: 1000,
+      tags: ["tag1", "tag2"],
+    });
+
+    expect(await prefixing.get("keyWithOptions")).toBe("bar");
+    expect(await inner.get("prefix:keyWithOptions")).toBe("bar");
+    await prefixing.delete("keyWithOptions");
+    expect(await prefixing.get("keyWithOptions")).toBe(undefined);
   });
 });

--- a/packages/keyvAdapter/src/index.ts
+++ b/packages/keyvAdapter/src/index.ts
@@ -12,7 +12,8 @@ interface KeyvAdapterOptions {
 export class KeyvAdapter<
   V = string,
   O extends Record<string, any> = Record<string, unknown>,
-> implements KeyValueCache<V>
+  SO extends KeyValueCacheSetOptions = KeyValueCacheSetOptions,
+> implements KeyValueCache<V, SO>
 {
   private readonly keyv: Keyv<V, O>;
   private readonly dataLoader: DataLoader<string, V | undefined> | undefined;
@@ -39,11 +40,7 @@ export class KeyvAdapter<
     return this.dataLoader ? this.dataLoader.load(key) : this.keyv.get(key);
   }
 
-  async set(
-    key: string,
-    value: V,
-    opts?: KeyValueCacheSetOptions,
-  ): Promise<void> {
+  async set(key: string, value: V, opts?: SO): Promise<void> {
     // Maybe an unnecessary precaution, just being careful with 0 here. Keyv
     // currently handles 0 as `undefined`. Also `NaN` is typeof `number`
     if (typeof opts?.ttl === "number" && !Number.isNaN(opts.ttl)) {


### PR DESCRIPTION
To be able to support custom key value caches that have additional cache set options, add an optional generic argument KeyValueCache to be able to specify a custom cache set option type.

Related to issue: https://github.com/apollographql/datasource-rest/issues/177