### PR TITLE
Add tests for existing functionality in generate-persisted-query-manifest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9930,7 +9930,8 @@
         "generate-persisted-query-manifest": "cli.js"
       },
       "devDependencies": {
-        "@gmrchk/cli-testing-library": "^0.1.2"
+        "@gmrchk/cli-testing-library": "^0.1.2",
+        "@wry/equality": "^0.5.6"
       },
       "engines": {
         "node": ">=16"
@@ -10209,6 +10210,7 @@
         "@apollo/persisted-query-lists": "^1.0.0",
         "@gmrchk/cli-testing-library": "^0.1.2",
         "@graphql-tools/graphql-tag-pluck": "^8.0.0",
+        "@wry/equality": "^0.5.6",
         "chalk": "^4.1.2",
         "commander": "^11.0.0",
         "cosmiconfig": "^8.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,6 +1156,15 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@gmrchk/cli-testing-library": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@gmrchk/cli-testing-library/-/cli-testing-library-0.1.2.tgz",
+      "integrity": "sha512-/oALX+4Zti+92hJaR7trZlDPzI2EekIHEYoDXH3oGTdCdgq5lDT3vHAMDzTjbIfUA0X/XC8sVA2tbtSoUPB5xw==",
+      "dev": true,
+      "dependencies": {
+        "keycode": "^2.2.1"
+      }
+    },
     "node_modules/@graphql-tools/graphql-tag-pluck": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-8.0.0.tgz",
@@ -6966,6 +6975,12 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/keycode": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.1.tgz",
+      "integrity": "sha512-Rdgz9Hl9Iv4QKi8b0OlCRQEzp4AgVxyCtz5S/+VIHezDmrDhkp2N2TqBWOLz0/gbeREXOOiI9/4b8BY9uw2vFg==",
+      "dev": true
+    },
     "node_modules/keyv": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.4.1.tgz",
@@ -9914,6 +9929,9 @@
       "bin": {
         "generate-persisted-query-manifest": "cli.js"
       },
+      "devDependencies": {
+        "@gmrchk/cli-testing-library": "^0.1.2"
+      },
       "engines": {
         "node": ">=16"
       },
@@ -10189,6 +10207,7 @@
       "version": "file:packages/generate-persisted-query-manifest",
       "requires": {
         "@apollo/persisted-query-lists": "^1.0.0",
+        "@gmrchk/cli-testing-library": "^0.1.2",
         "@graphql-tools/graphql-tag-pluck": "^8.0.0",
         "chalk": "^4.1.2",
         "commander": "^11.0.0",
@@ -11071,6 +11090,15 @@
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.47.0.tgz",
       "integrity": "sha512-P6omY1zv5MItm93kLM8s2vr1HICJH8v0dvddDhysbIuZ+vcjOHg5Zbkf1mTkcmi2JA9oBG2anOkRnW8WJTS8Og==",
       "dev": true
+    },
+    "@gmrchk/cli-testing-library": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@gmrchk/cli-testing-library/-/cli-testing-library-0.1.2.tgz",
+      "integrity": "sha512-/oALX+4Zti+92hJaR7trZlDPzI2EekIHEYoDXH3oGTdCdgq5lDT3vHAMDzTjbIfUA0X/XC8sVA2tbtSoUPB5xw==",
+      "dev": true,
+      "requires": {
+        "keycode": "^2.2.1"
+      }
     },
     "@graphql-tools/graphql-tag-pluck": {
       "version": "8.0.0",
@@ -15224,6 +15252,12 @@
       "requires": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "keycode": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.1.tgz",
+      "integrity": "sha512-Rdgz9Hl9Iv4QKi8b0OlCRQEzp4AgVxyCtz5S/+VIHezDmrDhkp2N2TqBWOLz0/gbeREXOOiI9/4b8BY9uw2vFg==",
+      "dev": true
     },
     "keyv": {
       "version": "4.4.1",

--- a/packages/generate-persisted-query-manifest/package.json
+++ b/packages/generate-persisted-query-manifest/package.json
@@ -38,5 +38,8 @@
   "peerDependencies": {
     "@apollo/client": "^3.7.0 || ^3.8.0-alpha",
     "graphql": "14.x || 15.x || 16.x"
+  },
+  "devDependencies": {
+    "@gmrchk/cli-testing-library": "^0.1.2"
   }
 }

--- a/packages/generate-persisted-query-manifest/package.json
+++ b/packages/generate-persisted-query-manifest/package.json
@@ -40,6 +40,7 @@
     "graphql": "14.x || 15.x || 16.x"
   },
   "devDependencies": {
-    "@gmrchk/cli-testing-library": "^0.1.2"
+    "@gmrchk/cli-testing-library": "^0.1.2",
+    "@wry/equality": "^0.5.6"
   }
 }

--- a/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
+++ b/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
@@ -1048,8 +1048,10 @@ async function setup() {
     return utils.writeFile(path, contents.trim());
   };
 
-  const runCommand = (args?: string) => {
-    return utils.execute("node", getCommand(args));
+  const runCommand = (...args: string[]) => {
+    const cli = path.resolve(__dirname, "../../cli.js");
+
+    return utils.execute("node", [cli, ...args].join(" "));
   };
 
   return { ...utils, writeFile, runCommand };
@@ -1061,10 +1063,6 @@ function sha256(query: DocumentNode) {
 
 function base64(query: DocumentNode) {
   return Buffer.from(print(query)).toString("base64");
-}
-
-function getCommand(args: string = "") {
-  return `${path.resolve(__dirname, "../../cli.js")} ${args}`.trim();
 }
 
 interface ApolloCustomMatchers<R = void> {

--- a/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
+++ b/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
@@ -459,6 +459,29 @@ test("can omit paths in document configuration with starting !", async () => {
   await cleanup();
 });
 
+test("can specify manifest output location using config file", async () => {
+  const { cleanup, runCommand, writeFile, exists } = await setup();
+  const query = gql`
+    query GreetingQuery {
+      greeting
+    }
+  `;
+
+  await writeFile("./src/greeting-query.graphql", print(query));
+
+  await writeFile(
+    "./persisted-query-manifest.config.json",
+    JSON.stringify({ output: "./pql.json" }),
+  );
+
+  const { code } = await runCommand();
+
+  expect(code).toBe(0);
+  expect(await exists("./pql.json")).toBe(true);
+
+  await cleanup();
+});
+
 async function setup() {
   const utils = await prepareEnvironment();
 

--- a/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
+++ b/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
@@ -1,0 +1,25 @@
+import path from "path";
+import { prepareEnvironment } from "@gmrchk/cli-testing-library";
+
+function getCommand(args: string = "") {
+  return `${path.resolve(__dirname, "../../cli.js")} ${args}`.trim();
+}
+
+test("Succeeds and writes manifest file with no operations", async () => {
+  const { execute, cleanup, readFile } = await prepareEnvironment();
+
+  const { code, stdout } = await execute("node", getCommand());
+
+  const manifest = await readFile("./persisted-query-manifest.json");
+
+  expect(stdout).toEqual(["Manifest written to persisted-query-manifest.json"]);
+  expect(code).toBe(0);
+
+  expect(JSON.parse(manifest)).toEqual({
+    format: "apollo-persisted-query-manifest",
+    version: 1,
+    operations: [],
+  });
+
+  await cleanup();
+});

--- a/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
+++ b/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
@@ -1,9 +1,8 @@
 import path from "path";
 import { prepareEnvironment } from "@gmrchk/cli-testing-library";
-
-function getCommand(args: string = "") {
-  return `${path.resolve(__dirname, "../../cli.js")} ${args}`.trim();
-}
+import { createHash } from "node:crypto";
+import { equal } from "@wry/equality";
+import type { PersistedQueryManifestOperation } from "../index";
 
 test("Succeeds and writes manifest file with no operations", async () => {
   const { execute, cleanup, readFile } = await prepareEnvironment();
@@ -15,11 +14,76 @@ test("Succeeds and writes manifest file with no operations", async () => {
   expect(stdout).toEqual(["Manifest written to persisted-query-manifest.json"]);
   expect(code).toBe(0);
 
-  expect(JSON.parse(manifest)).toEqual({
-    format: "apollo-persisted-query-manifest",
-    version: 1,
-    operations: [],
-  });
+  expect(manifest).toBeManifestWithOperations([]);
 
   await cleanup();
+});
+
+test("Can read operations from .graphql files by default", async () => {
+  const query = `
+query GreetingQuery {
+  greeting
+}
+`.trim();
+  const { execute, cleanup, writeFile, readFile } = await prepareEnvironment();
+
+  await writeFile("./src/query.graphql", query);
+
+  const { code } = await execute("node", getCommand());
+
+  const manifest = await readFile("./persisted-query-manifest.json");
+
+  expect(code).toBe(0);
+  expect(manifest).toBeManifestWithOperations([
+    { id: sha256(query), name: "GreetingQuery", body: query, type: "query" },
+  ]);
+
+  await cleanup();
+});
+
+function sha256(query: string) {
+  return createHash("sha256").update(query).digest("hex");
+}
+
+function getCommand(args: string = "") {
+  return `${path.resolve(__dirname, "../../cli.js")} ${args}`.trim();
+}
+
+interface ApolloCustomMatchers<R = void> {
+  toBeManifestWithOperations(operations: PersistedQueryManifestOperation[]): R;
+}
+
+declare global {
+  namespace jest {
+    interface Matchers<R = void> extends ApolloCustomMatchers<R> {}
+  }
+}
+
+expect.extend({
+  toBeManifestWithOperations(
+    manifestJSON: string,
+    operations: PersistedQueryManifestOperation[],
+  ) {
+    const manifest = JSON.parse(manifestJSON) as Record<string, unknown>;
+    const pass = equal(manifest, {
+      format: "apollo-persisted-query-manifest",
+      version: 1,
+      operations,
+    });
+
+    return {
+      pass,
+      message: () => {
+        const diff = this.utils.diff(manifest, {
+          format: "apollo-persisted-query-manifest",
+          version: 1,
+          operations,
+        });
+
+        return `Expected manifest ${
+          this.isNot ? "not " : ""
+        }to be persisted query manifest.\n\n${diff}`;
+      },
+    };
+  },
 });

--- a/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
+++ b/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
@@ -637,6 +637,30 @@ export default config;
   await cleanup();
 });
 
+test("errors on anonymous operations", async () => {
+  const { cleanup, runCommand, writeFile } = await setup();
+  const query = gql`
+    query {
+      greeting
+    }
+  `;
+
+  await writeFile("./src/query.graphql", print(query));
+
+  const { code, stderr } = await runCommand();
+
+  expect(code).toBe(1);
+  expect(stderr).toMatchInlineSnapshot(`
+    [
+      "src/query.graphql",
+      "1:1  error  Anonymous GraphQL operations are not supported. Please name your query.",
+      "✖ 1 error",
+    ]
+  `);
+
+  await cleanup();
+});
+
 async function setup() {
   const utils = await prepareEnvironment();
 

--- a/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
+++ b/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
@@ -53,7 +53,7 @@ test("writes manifest file and prints location", async () => {
   await cleanup();
 });
 
-test("can read operations from .graphql files", async () => {
+test("can extract operations from .graphql files", async () => {
   const query = gql`
     query GreetingQuery {
       greeting
@@ -80,7 +80,7 @@ test("can read operations from .graphql files", async () => {
   await cleanup();
 });
 
-test("can read operations from .gql files", async () => {
+test("can extract operations from .gql files", async () => {
   const query = gql`
     query GreetingQuery {
       greeting

--- a/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
+++ b/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
@@ -1,7 +1,8 @@
-import path from "path";
+import path from "node:path";
 import { prepareEnvironment } from "@gmrchk/cli-testing-library";
 import { createHash } from "node:crypto";
 import { equal } from "@wry/equality";
+import { readFileSync } from "node:fs";
 import type { PersistedQueryManifestOperation } from "../index";
 
 test("prints help message with --help", async () => {
@@ -20,6 +21,20 @@ test("prints help message with --help", async () => {
       "-h, --help           display help for command",
     ]
   `);
+
+  await cleanup();
+});
+
+test("prints version number with --version", async () => {
+  const { execute, cleanup } = await prepareEnvironment();
+  const { version } = JSON.parse(
+    readFileSync(path.resolve(__dirname, "../../package.json"), "utf8"),
+  );
+
+  const { code, stdout } = await execute("node", getCommand("--version"));
+
+  expect(code).toBe(0);
+  expect(stdout).toEqual([version]);
 
   await cleanup();
 });

--- a/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
+++ b/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
@@ -1,4 +1,6 @@
 import path from "node:path";
+import { gql } from "@apollo/client/core";
+import { type DocumentNode, print } from "graphql";
 import { prepareEnvironment } from "@gmrchk/cli-testing-library";
 import { createHash } from "node:crypto";
 import { equal } from "@wry/equality";
@@ -52,14 +54,14 @@ test("writes manifest file and prints location", async () => {
 });
 
 test("can read operations from .graphql files", async () => {
-  const query = `
-query GreetingQuery {
-  greeting
-}
-`.trim();
+  const query = gql`
+    query GreetingQuery {
+      greeting
+    }
+  `;
   const { cleanup, writeFile, readFile, runCommand } = await setup();
 
-  await writeFile("./src/query.graphql", query);
+  await writeFile("./src/query.graphql", print(query));
 
   const { code } = await runCommand();
 
@@ -67,21 +69,26 @@ query GreetingQuery {
 
   expect(code).toBe(0);
   expect(manifest).toBeManifestWithOperations([
-    { id: sha256(query), name: "GreetingQuery", body: query, type: "query" },
+    {
+      id: sha256(query),
+      name: "GreetingQuery",
+      body: print(query),
+      type: "query",
+    },
   ]);
 
   await cleanup();
 });
 
 test("can read operations from .gql files", async () => {
-  const query = `
-query GreetingQuery {
-  greeting
-}
-`.trim();
+  const query = gql`
+    query GreetingQuery {
+      greeting
+    }
+  `;
   const { cleanup, writeFile, readFile, runCommand } = await setup();
 
-  await writeFile("./src/query.gql", query);
+  await writeFile("./src/query.gql", print(query));
 
   const { code } = await runCommand();
 
@@ -89,7 +96,12 @@ query GreetingQuery {
 
   expect(code).toBe(0);
   expect(manifest).toBeManifestWithOperations([
-    { id: sha256(query), name: "GreetingQuery", body: query, type: "query" },
+    {
+      id: sha256(query),
+      name: "GreetingQuery",
+      body: print(query),
+      type: "query",
+    },
   ]);
 
   await cleanup();
@@ -97,11 +109,11 @@ query GreetingQuery {
 
 test("can extract operations from JavaScript files", async () => {
   const { cleanup, writeFile, readFile, runCommand } = await setup();
-  const query = `
-query GreetingQuery {
-  greeting
-}
-`.trim();
+  const query = gql`
+    query GreetingQuery {
+      greeting
+    }
+  `;
 
   await writeFile(
     "./src/my-component.js",
@@ -122,7 +134,12 @@ const QUERY = gql\`
 
   expect(code).toBe(0);
   expect(manifest).toBeManifestWithOperations([
-    { id: sha256(query), name: "GreetingQuery", body: query, type: "query" },
+    {
+      id: sha256(query),
+      name: "GreetingQuery",
+      body: print(query),
+      type: "query",
+    },
   ]);
 
   await cleanup();
@@ -130,11 +147,11 @@ const QUERY = gql\`
 
 test("can extract operations from TypeScript files", async () => {
   const { cleanup, writeFile, readFile, runCommand } = await setup();
-  const query = `
-query GreetingQuery {
-  greeting
-}
-`.trim();
+  const query = gql`
+    query GreetingQuery {
+      greeting
+    }
+  `;
 
   await writeFile(
     "./src/my-component.ts",
@@ -156,7 +173,12 @@ const QUERY: TypedDocumentNode<GreetingQueryType> = gql\`
 
   expect(code).toBe(0);
   expect(manifest).toBeManifestWithOperations([
-    { id: sha256(query), name: "GreetingQuery", body: query, type: "query" },
+    {
+      id: sha256(query),
+      name: "GreetingQuery",
+      body: print(query),
+      type: "query",
+    },
   ]);
 
   await cleanup();
@@ -164,11 +186,11 @@ const QUERY: TypedDocumentNode<GreetingQueryType> = gql\`
 
 test("can extract operations from TypeScript React files", async () => {
   const { cleanup, writeFile, readFile, runCommand } = await setup();
-  const query = `
-query GreetingQuery {
-  greeting
-}
-`.trim();
+  const query = gql`
+    query GreetingQuery {
+      greeting
+    }
+  `;
 
   await writeFile(
     "./src/my-component.tsx",
@@ -198,7 +220,12 @@ export default Greeting;
 
   expect(code).toBe(0);
   expect(manifest).toBeManifestWithOperations([
-    { id: sha256(query), name: "GreetingQuery", body: query, type: "query" },
+    {
+      id: sha256(query),
+      name: "GreetingQuery",
+      body: print(query),
+      type: "query",
+    },
   ]);
 
   await cleanup();
@@ -206,20 +233,20 @@ export default Greeting;
 
 test("can extract multiple operations", async () => {
   const { cleanup, writeFile, readFile, runCommand } = await setup();
-  const query = `
-query GreetingQuery {
-  greeting
-}
-`.trim();
+  const query = gql`
+    query GreetingQuery {
+      greeting
+    }
+  `;
 
-  const query2 = `
-query HelloQuery {
-  hello
-}
-`.trim();
+  const query2 = gql`
+    query HelloQuery {
+      hello
+    }
+  `;
 
-  await writeFile("./src/greeting-query.graphql", query);
-  await writeFile("./src/hello-query.graphql", query2);
+  await writeFile("./src/greeting-query.graphql", print(query));
+  await writeFile("./src/hello-query.graphql", print(query2));
 
   const { code } = await runCommand();
 
@@ -227,8 +254,18 @@ query HelloQuery {
 
   expect(code).toBe(0);
   expect(manifest).toBeManifestWithOperations([
-    { id: sha256(query), name: "GreetingQuery", body: query, type: "query" },
-    { id: sha256(query2), name: "HelloQuery", body: query2, type: "query" },
+    {
+      id: sha256(query),
+      name: "GreetingQuery",
+      body: print(query),
+      type: "query",
+    },
+    {
+      id: sha256(query2),
+      name: "HelloQuery",
+      body: print(query2),
+      type: "query",
+    },
   ]);
 
   await cleanup();
@@ -236,16 +273,16 @@ query HelloQuery {
 
 test("can extract mutations", async () => {
   const { cleanup, writeFile, readFile, runCommand } = await setup();
-  const mutation = `
-mutation CreateUserMutation($user: UserInput!) {
-  createUser(user: $user) {
-    __typename
-    id
-  }
-}
-`.trim();
+  const mutation = gql`
+    mutation CreateUserMutation($user: UserInput!) {
+      createUser(user: $user) {
+        __typename
+        id
+      }
+    }
+  `;
 
-  await writeFile("./src/create-user-mutation.graphql", mutation);
+  await writeFile("./src/create-user-mutation.graphql", print(mutation));
 
   const { code } = await runCommand();
 
@@ -256,7 +293,7 @@ mutation CreateUserMutation($user: UserInput!) {
     {
       id: sha256(mutation),
       name: "CreateUserMutation",
-      body: mutation,
+      body: print(mutation),
       type: "mutation",
     },
   ]);
@@ -266,16 +303,19 @@ mutation CreateUserMutation($user: UserInput!) {
 
 test("can extract subscriptions", async () => {
   const { cleanup, writeFile, readFile, runCommand } = await setup();
-  const subscription = `
-subscription UserCreatedSubscription($id: ID!) {
-  userCreated(id: $id) {
-    __typename
-    id
-  }
-}
-`.trim();
+  const subscription = gql`
+    subscription UserCreatedSubscription($id: ID!) {
+      userCreated(id: $id) {
+        __typename
+        id
+      }
+    }
+  `;
 
-  await writeFile("./src/user-created-subscription.graphql", subscription);
+  await writeFile(
+    "./src/user-created-subscription.graphql",
+    print(subscription),
+  );
 
   const { code } = await runCommand();
 
@@ -286,7 +326,7 @@ subscription UserCreatedSubscription($id: ID!) {
     {
       id: sha256(subscription),
       name: "UserCreatedSubscription",
-      body: subscription,
+      body: print(subscription),
       type: "subscription",
     },
   ]);
@@ -321,8 +361,8 @@ async function setup() {
   return { ...utils, writeFile, runCommand };
 }
 
-function sha256(query: string) {
-  return createHash("sha256").update(query.trim()).digest("hex");
+function sha256(query: DocumentNode) {
+  return createHash("sha256").update(print(query)).digest("hex");
 }
 
 function getCommand(args: string = "") {

--- a/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
+++ b/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
@@ -1,12 +1,12 @@
-import path from "node:path";
 import { gql } from "@apollo/client/core";
-import { type DocumentNode, print } from "graphql";
-import { prepareEnvironment } from "@gmrchk/cli-testing-library";
-import { createHash } from "node:crypto";
-import { equal } from "@wry/equality";
-import { readFileSync } from "node:fs";
-import type { PersistedQueryManifestOperation } from "../index";
 import { addTypenameToDocument } from "@apollo/client/utilities";
+import { prepareEnvironment } from "@gmrchk/cli-testing-library";
+import { equal } from "@wry/equality";
+import { print, type DocumentNode } from "graphql";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import type { PersistedQueryManifestOperation } from "../index";
 
 test("prints help message with --help", async () => {
   const { cleanup, runCommand } = await setup();

--- a/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
+++ b/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
@@ -6,9 +6,9 @@ import { readFileSync } from "node:fs";
 import type { PersistedQueryManifestOperation } from "../index";
 
 test("prints help message with --help", async () => {
-  const { execute, cleanup } = await prepareEnvironment();
+  const { cleanup, runCommand } = await setup();
 
-  const { code, stdout } = await execute("node", getCommand("--help"));
+  const { code, stdout } = await runCommand("--help");
 
   expect(code).toBe(0);
   expect(stdout).toMatchInlineSnapshot(`
@@ -26,12 +26,12 @@ test("prints help message with --help", async () => {
 });
 
 test("prints version number with --version", async () => {
-  const { execute, cleanup } = await prepareEnvironment();
+  const { cleanup, runCommand } = await setup();
   const { version } = JSON.parse(
     readFileSync(path.resolve(__dirname, "../../package.json"), "utf8"),
   );
 
-  const { code, stdout } = await execute("node", getCommand("--version"));
+  const { code, stdout } = await runCommand("--version");
 
   expect(code).toBe(0);
   expect(stdout).toEqual([version]);
@@ -40,9 +40,9 @@ test("prints version number with --version", async () => {
 });
 
 test("writes manifest file and prints location", async () => {
-  const { execute, cleanup, exists } = await prepareEnvironment();
+  const { cleanup, exists, runCommand } = await setup();
 
-  const { code, stdout } = await execute("node", getCommand());
+  const { code, stdout } = await runCommand();
 
   expect(stdout).toEqual(["Manifest written to persisted-query-manifest.json"]);
   expect(code).toBe(0);
@@ -57,11 +57,11 @@ query GreetingQuery {
   greeting
 }
 `.trim();
-  const { execute, cleanup, writeFile, readFile } = await prepareEnvironment();
+  const { cleanup, writeFile, readFile, runCommand } = await setup();
 
   await writeFile("./src/query.graphql", query);
 
-  const { code } = await execute("node", getCommand());
+  const { code } = await runCommand();
 
   const manifest = await readFile("./persisted-query-manifest.json");
 
@@ -79,11 +79,11 @@ query GreetingQuery {
   greeting
 }
 `.trim();
-  const { execute, cleanup, writeFile, readFile } = await prepareEnvironment();
+  const { cleanup, writeFile, readFile, runCommand } = await setup();
 
   await writeFile("./src/query.gql", query);
 
-  const { code } = await execute("node", getCommand());
+  const { code } = await runCommand();
 
   const manifest = await readFile("./persisted-query-manifest.json");
 
@@ -96,7 +96,7 @@ query GreetingQuery {
 });
 
 test("can extract operations from JavaScript files", async () => {
-  const { execute, cleanup, writeFile, readFile } = await prepareEnvironment();
+  const { cleanup, writeFile, readFile, runCommand } = await setup();
   const query = `
 query GreetingQuery {
   greeting
@@ -113,10 +113,10 @@ const QUERY = gql\`
     greeting
   }
 \`;
-`.trim(),
+`,
   );
 
-  const { code } = await execute("node", getCommand());
+  const { code } = await runCommand();
 
   const manifest = await readFile("./persisted-query-manifest.json");
 
@@ -129,7 +129,7 @@ const QUERY = gql\`
 });
 
 test("can extract operations from TypeScript files", async () => {
-  const { execute, cleanup, writeFile, readFile } = await prepareEnvironment();
+  const { cleanup, writeFile, readFile, runCommand } = await setup();
   const query = `
 query GreetingQuery {
   greeting
@@ -147,10 +147,10 @@ const QUERY: TypedDocumentNode<GreetingQueryType> = gql\`
     greeting
   }
 \`;
-`.trim(),
+`,
   );
 
-  const { code } = await execute("node", getCommand());
+  const { code } = await runCommand();
 
   const manifest = await readFile("./persisted-query-manifest.json");
 
@@ -163,7 +163,7 @@ const QUERY: TypedDocumentNode<GreetingQueryType> = gql\`
 });
 
 test("can extract operations from TypeScript React files", async () => {
-  const { execute, cleanup, writeFile, readFile } = await prepareEnvironment();
+  const { cleanup, writeFile, readFile, runCommand } = await setup();
   const query = `
 query GreetingQuery {
   greeting
@@ -189,10 +189,10 @@ function Greeting() {
 }
 
 export default Greeting;
-`.trim(),
+`,
   );
 
-  const { code } = await execute("node", getCommand());
+  const { code } = await runCommand();
 
   const manifest = await readFile("./persisted-query-manifest.json");
 
@@ -205,7 +205,7 @@ export default Greeting;
 });
 
 test("can extract multiple operations", async () => {
-  const { execute, cleanup, writeFile, readFile } = await prepareEnvironment();
+  const { cleanup, writeFile, readFile, runCommand } = await setup();
   const query = `
 query GreetingQuery {
   greeting
@@ -221,7 +221,7 @@ query HelloQuery {
   await writeFile("./src/greeting-query.graphql", query);
   await writeFile("./src/hello-query.graphql", query2);
 
-  const { code } = await execute("node", getCommand());
+  const { code } = await runCommand();
 
   const manifest = await readFile("./persisted-query-manifest.json");
 
@@ -235,7 +235,7 @@ query HelloQuery {
 });
 
 test("can extract mutations", async () => {
-  const { execute, cleanup, writeFile, readFile } = await prepareEnvironment();
+  const { cleanup, writeFile, readFile, runCommand } = await setup();
   const mutation = `
 mutation CreateUserMutation($user: UserInput!) {
   createUser(user: $user) {
@@ -247,7 +247,7 @@ mutation CreateUserMutation($user: UserInput!) {
 
   await writeFile("./src/create-user-mutation.graphql", mutation);
 
-  const { code } = await execute("node", getCommand());
+  const { code } = await runCommand();
 
   const manifest = await readFile("./persisted-query-manifest.json");
 
@@ -265,7 +265,7 @@ mutation CreateUserMutation($user: UserInput!) {
 });
 
 test("can extract subscriptions", async () => {
-  const { execute, cleanup, writeFile, readFile } = await prepareEnvironment();
+  const { cleanup, writeFile, readFile, runCommand } = await setup();
   const subscription = `
 subscription UserCreatedSubscription($id: ID!) {
   userCreated(id: $id) {
@@ -277,7 +277,7 @@ subscription UserCreatedSubscription($id: ID!) {
 
   await writeFile("./src/user-created-subscription.graphql", subscription);
 
-  const { code } = await execute("node", getCommand());
+  const { code } = await runCommand();
 
   const manifest = await readFile("./persisted-query-manifest.json");
 
@@ -295,9 +295,9 @@ subscription UserCreatedSubscription($id: ID!) {
 });
 
 test("writes manifest file with no operations when none found", async () => {
-  const { execute, cleanup, readFile } = await prepareEnvironment();
+  const { cleanup, readFile, runCommand } = await setup();
 
-  const { code } = await execute("node", getCommand());
+  const { code } = await runCommand();
 
   const manifest = await readFile("./persisted-query-manifest.json");
 
@@ -307,8 +307,22 @@ test("writes manifest file with no operations when none found", async () => {
   await cleanup();
 });
 
+async function setup() {
+  const utils = await prepareEnvironment();
+
+  const writeFile: typeof utils.writeFile = (path, contents) => {
+    return utils.writeFile(path, contents.trim());
+  };
+
+  const runCommand = (args?: string) => {
+    return utils.execute("node", getCommand(args));
+  };
+
+  return { ...utils, writeFile, runCommand };
+}
+
 function sha256(query: string) {
-  return createHash("sha256").update(query).digest("hex");
+  return createHash("sha256").update(query.trim()).digest("hex");
 }
 
 function getCommand(args: string = "") {

--- a/packages/generate-persisted-query-manifest/src/__tests__/generatePersistedQueryManifest.test.ts
+++ b/packages/generate-persisted-query-manifest/src/__tests__/generatePersistedQueryManifest.test.ts
@@ -1,3 +1,0 @@
-describe("generatePersistedQueryManifest", () => {
-  it("basic test", () => {});
-});


### PR DESCRIPTION
Adds a full test suite for the CLI for the `@apollo/generate-persisted-query-manifest` package. 