### PR TITLE
Add CLI option to `generate-persisted-query-manifest` that lists all matched files using the `documents` pattern

### DIFF
--- a/.changeset/poor-flowers-sin.md
+++ b/.changeset/poor-flowers-sin.md
@@ -1,0 +1,5 @@
+---
+"@apollo/generate-persisted-query-manifest": minor
+---
+
+Add a `--list-files` option that lists the set of matched files against the `documents` pattern.

--- a/packages/generate-persisted-query-manifest/cli.js
+++ b/packages/generate-persisted-query-manifest/cli.js
@@ -10,6 +10,7 @@ const {
 const { TypeScriptLoader } = require("cosmiconfig-typescript-loader");
 const { version } = require("./package.json");
 const { writeFileSync } = require("node:fs");
+const chalk = require("chalk");
 
 const program = new Command();
 
@@ -32,6 +33,14 @@ async function getUserConfig({ config: configPath }) {
   return configPath ? explorer.load(configPath) : explorer.search();
 }
 
+async function listFiles(config) {
+  const filepaths = await getFilepaths(config?.documents ?? defaults.documents);
+
+  if (filepaths.length > 0) {
+    console.log(filepaths.join("\n"));
+  }
+}
+
 program
   .name("generate-persisted-query-manifest")
   .description("Generate a persisted query manifest file")
@@ -45,11 +54,7 @@ program
     const result = await getUserConfig(cliOptions);
 
     if (cliOptions.listFiles) {
-      const filepaths = await getFilepaths(
-        result?.config.documents ?? defaults.documents,
-      );
-
-      console.log(filepaths.join("\n"));
+      await listFiles(result?.config);
       process.exit(0);
     }
 

--- a/packages/generate-persisted-query-manifest/cli.js
+++ b/packages/generate-persisted-query-manifest/cli.js
@@ -2,7 +2,11 @@
 
 const { Command } = require("commander");
 const { cosmiconfig } = require("cosmiconfig");
-const { generatePersistedQueryManifest, defaults } = require("./dist/index.js");
+const {
+  generatePersistedQueryManifest,
+  getFilepaths,
+  defaults,
+} = require("./dist/index.js");
 const { TypeScriptLoader } = require("cosmiconfig-typescript-loader");
 const { version } = require("./package.json");
 const { writeFileSync } = require("node:fs");
@@ -39,6 +43,16 @@ program
   .version(version, "-v, --version")
   .action(async (cliOptions) => {
     const result = await getUserConfig(cliOptions);
+
+    if (cliOptions.listFiles) {
+      const filepaths = await getFilepaths(
+        result?.config.documents ?? defaults.documents,
+      );
+
+      console.log(filepaths.join("\n"));
+      process.exit(0);
+    }
+
     const outputPath = result?.config.output ?? defaults.output;
 
     const manifest = await generatePersistedQueryManifest(

--- a/packages/generate-persisted-query-manifest/cli.js
+++ b/packages/generate-persisted-query-manifest/cli.js
@@ -32,6 +32,10 @@ program
   .name("generate-persisted-query-manifest")
   .description("Generate a persisted query manifest file")
   .option("-c, --config <path>", "path to the config file")
+  .option(
+    "-l, --list-files",
+    "prints the files matched from the documents pattern",
+  )
   .version(version, "-v, --version")
   .action(async (cliOptions) => {
     const result = await getUserConfig(cliOptions);

--- a/packages/generate-persisted-query-manifest/cli.js
+++ b/packages/generate-persisted-query-manifest/cli.js
@@ -10,7 +10,6 @@ const {
 const { TypeScriptLoader } = require("cosmiconfig-typescript-loader");
 const { version } = require("./package.json");
 const { writeFileSync } = require("node:fs");
-const chalk = require("chalk");
 
 const program = new Command();
 

--- a/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
+++ b/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
@@ -46,6 +46,31 @@ test("prints version number with --version", async () => {
   await cleanup();
 });
 
+test("prints list of matched files with --list-files option", async () => {
+  const { cleanup, runCommand, writeFile } = await setup();
+
+  await writeFile("./src/query.graphql", "");
+  await writeFile("./src/components/legacy.js", "");
+  await writeFile("./src/components/my-component.tsx", "");
+  await writeFile("./src/queries/root.graphql", "");
+  // Include a file that isn't part of the globbed pattern
+  await writeFile("./not-included.ts", "");
+
+  const { code, stdout } = await runCommand("--list-files");
+
+  expect(code).toBe(0);
+  expect(stdout).toMatchInlineSnapshot(`
+    [
+      "src/query.graphql",
+      "src/components/legacy.js",
+      "src/components/my-component.tsx",
+      "src/queries/root.graphql",
+    ]
+  `);
+
+  await cleanup();
+});
+
 test("writes manifest file and prints location", async () => {
   const { cleanup, exists, runCommand } = await setup();
 

--- a/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
+++ b/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
@@ -23,6 +23,7 @@ test("prints help message with --help", async () => {
       "Generate a persisted query manifest file",
       "Options:",
       "-c, --config <path>  path to the config file",
+      "-l, --list-files     prints the files matched from the documents pattern",
       "-v, --version        output the version number",
       "-h, --help           display help for command",
     ]

--- a/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
+++ b/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
@@ -61,10 +61,10 @@ test("prints list of matched files with --list-files option", async () => {
   expect(code).toBe(0);
   expect(stdout).toMatchInlineSnapshot(`
     [
-      "src/query.graphql",
       "src/components/legacy.js",
       "src/components/my-component.tsx",
       "src/queries/root.graphql",
+      "src/query.graphql",
     ]
   `);
 

--- a/packages/generate-persisted-query-manifest/src/index.ts
+++ b/packages/generate-persisted-query-manifest/src/index.ts
@@ -176,6 +176,10 @@ function uniq<T>(arr: T[]) {
   return [...new Set(arr)];
 }
 
+export async function getFilepaths(documents: string | string[]) {
+  return uniq(await globby(documents));
+}
+
 export async function generatePersistedQueryManifest(
   config: PersistedQueryManifestConfig = {},
   configFilePath: string | undefined,
@@ -190,8 +194,8 @@ export async function generatePersistedQueryManifest(
       ? relative(process.cwd(), configFilePath)
       : "<virtual>",
   });
-  const filepaths = await globby(documents);
-  const sources = uniq(filepaths).flatMap(getDocumentSources);
+  const filepaths = await getFilepaths(documents);
+  const sources = filepaths.flatMap(getDocumentSources);
 
   const fragmentsByName = new Map<string, DocumentSource[]>();
   const operationsByName = new Map<string, DocumentSource[]>();

--- a/packages/generate-persisted-query-manifest/src/index.ts
+++ b/packages/generate-persisted-query-manifest/src/index.ts
@@ -176,8 +176,12 @@ function uniq<T>(arr: T[]) {
   return [...new Set(arr)];
 }
 
+// Unfortunately globby does not guarantee deterministic file sorting so we
+// apply some sorting on the files in this function.
+//
+// https://github.com/sindresorhus/globby/issues/131
 export async function getFilepaths(documents: string | string[]) {
-  return uniq(await globby(documents));
+  return [...uniq(await globby(documents))].sort((a, b) => a.localeCompare(b));
 }
 
 export async function generatePersistedQueryManifest(


### PR DESCRIPTION
Adds a `--list-files` option to the CLI that will print the list of files matched against the configured `documents` pattern. This can be useful for debugging why the command may or may not be including/not including specific queries in the manifest.