### PR TITLE
Log warning when no operations are found and add number of operations matched during generation

### DIFF
--- a/.changeset/violet-zoos-shout.md
+++ b/.changeset/violet-zoos-shout.md
@@ -1,0 +1,5 @@
+---
+"@apollo/generate-persisted-query-manifest": patch
+---
+
+Adds the number of matched operations recorded to the manifest file in the success message once the CLI finishes. If no operations were found, a warning is now logged.

--- a/packages/generate-persisted-query-manifest/cli.js
+++ b/packages/generate-persisted-query-manifest/cli.js
@@ -66,7 +66,9 @@ program
     );
     writeFileSync(outputPath, JSON.stringify(manifest, null, 2));
 
-    if (manifest.operations.length === 0) {
+    const numOperations = manifest.operations.length;
+
+    if (numOperations === 0) {
       console.warn(
         chalk.yellow(
           "Warning: no operations found during manifest generation. " +
@@ -78,9 +80,11 @@ program
     }
 
     console.log(
-      `${chalk.green("✓")} Manifest written to ${outputPath} with ${
-        manifest.operations.length
-      } operations.`,
+      `${chalk.green(
+        "✓",
+      )} Manifest written to ${outputPath} with ${numOperations} ${
+        numOperations === 1 ? "operation" : "operations"
+      }.`,
     );
   });
 

--- a/packages/generate-persisted-query-manifest/cli.js
+++ b/packages/generate-persisted-query-manifest/cli.js
@@ -10,6 +10,7 @@ const {
 const { TypeScriptLoader } = require("cosmiconfig-typescript-loader");
 const { version } = require("./package.json");
 const { writeFileSync } = require("node:fs");
+const chalk = require("chalk");
 
 const program = new Command();
 
@@ -65,7 +66,20 @@ program
     );
     writeFileSync(outputPath, JSON.stringify(manifest, null, 2));
 
-    console.log(`Manifest written to ${outputPath}`);
+    if (manifest.operations.length === 0) {
+      console.warn(
+        chalk.yellow(
+          "Warning: no operations found during manifest generation. " +
+            "You may need to adjust the glob pattern used to search " +
+            "files in this project. See the README for more information on how to configure the glob pattern: " +
+            "https://www.npmjs.com/package/@apollo/generate-persisted-query-manifest\n",
+        ),
+      );
+    }
+
+    console.log(
+      `Manifest written to ${outputPath} with ${manifest.operations.length} operations.`,
+    );
   });
 
 program.parse();

--- a/packages/generate-persisted-query-manifest/cli.js
+++ b/packages/generate-persisted-query-manifest/cli.js
@@ -78,7 +78,9 @@ program
     }
 
     console.log(
-      `Manifest written to ${outputPath} with ${manifest.operations.length} operations.`,
+      `${chalk.green("✓")} Manifest written to ${outputPath} with ${
+        manifest.operations.length
+      } operations.`,
     );
   });
 

--- a/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
+++ b/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
@@ -76,7 +76,9 @@ test("writes manifest file and prints location", async () => {
 
   const { code, stdout } = await runCommand();
 
-  expect(stdout).toEqual(["Manifest written to persisted-query-manifest.json"]);
+  expect(stdout).toEqual([
+    "Manifest written to persisted-query-manifest.json with 0 operations.",
+  ]);
   expect(code).toBe(0);
   expect(await exists("./persisted-query-manifest.json")).toBe(true);
 
@@ -602,15 +604,23 @@ export const fragment = gql\`
   await cleanup();
 });
 
-test("writes manifest file with no operations when none found", async () => {
+test("writes manifest file and logs warning when no operations are found", async () => {
   const { cleanup, readFile, runCommand } = await setup();
 
-  const { code } = await runCommand();
+  const { code, stdout, stderr } = await runCommand();
 
   const manifest = await readFile("./persisted-query-manifest.json");
 
   expect(code).toBe(0);
   expect(manifest).toBeManifestWithOperations([]);
+  expect(stderr).toMatchInlineSnapshot(`
+    [
+      "Warning: no operations found during manifest generation. You may need to adjust the glob pattern used to search files in this project. See the README for more information on how to configure the glob pattern: https://www.npmjs.com/package/@apollo/generate-persisted-query-manifest",
+    ]
+  `);
+  expect(stdout).toEqual([
+    "Manifest written to persisted-query-manifest.json with 0 operations.",
+  ]);
 
   await cleanup();
 });

--- a/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
+++ b/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
@@ -77,7 +77,7 @@ test("writes manifest file and prints location", async () => {
   const { code, stdout } = await runCommand();
 
   expect(stdout).toEqual([
-    "Manifest written to persisted-query-manifest.json with 0 operations.",
+    "✓ Manifest written to persisted-query-manifest.json with 0 operations.",
   ]);
   expect(code).toBe(0);
   expect(await exists("./persisted-query-manifest.json")).toBe(true);
@@ -619,7 +619,7 @@ test("writes manifest file and logs warning when no operations are found", async
     ]
   `);
   expect(stdout).toEqual([
-    "Manifest written to persisted-query-manifest.json with 0 operations.",
+    "✓ Manifest written to persisted-query-manifest.json with 0 operations.",
   ]);
 
   await cleanup();


### PR DESCRIPTION
When generating a persisted query manifest file, its possible that no operations were found during manifest generation, which could be due to a misconfiguration of the glob pattern used to search for operations. Currently the user has to run the command, then open the manifest file to see if operations were added which can be pretty cumbersome. This PR updates the terminal output to list the number of matched operations. If none were found, a warning is displayed as well.