### PR TITLE
Adds prettier v2 for Jest to get inline snapshots working again

### DIFF
--- a/jest.config.base.ts
+++ b/jest.config.base.ts
@@ -13,6 +13,13 @@ const config: Config.InitialOptions = {
       },
     ],
   },
+  // Prettier 3 is incompatible with jest at the time of this writing and needed
+  // to generate inline snapshot tests. As a temporary workaround, we use
+  // prettier v2 for Jest to allow inline snapshots to continue working.
+  // See https://jestjs.io/docs/configuration#prettierpath-string for more info
+  // on this fix and https://github.com/jestjs/jest/issues/14305 for tracking
+  // this issue.
+  prettierPath: require.resolve("prettier-2"),
 };
 
 export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "make-fetch-happen": "12.0.0",
         "node-fetch": "2.6.12",
         "prettier": "3.0.1",
+        "prettier-2": "npm:prettier@^2",
         "ts-expect": "1.3.0",
         "ts-jest": "29.1.1",
         "ts-node": "10.9.1",
@@ -8017,6 +8018,22 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/prettier-2": {
+      "name": "prettier",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "29.6.2",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.2.tgz",
@@ -15968,6 +15985,12 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.1.tgz",
       "integrity": "sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==",
+      "dev": true
+    },
+    "prettier-2": {
+      "version": "npm:prettier@2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "make-fetch-happen": "12.0.0",
     "node-fetch": "2.6.12",
     "prettier": "3.0.1",
+    "prettier-2": "npm:prettier@^2",
     "ts-expect": "1.3.0",
     "ts-jest": "29.1.1",
     "ts-node": "10.9.1",


### PR DESCRIPTION
Prettier v3 is currently not compatible with Jest inline snapshots (https://github.com/jestjs/jest/issues/14305). When trying to use an inline snapshot, the following error is displayed:

```
 FAIL   generate-persisted-query-manifest  packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
  ● Test suite failed to run

    Jest: Inline Snapshots are not supported when using Prettier 3.0.0 or above.
    See https://jestjs.io/docs/configuration/#prettierpath-string for alternatives.

      at saveInlineSnapshots (../../node_modules/jest-snapshot/build/InlineSnapshots.js:101:15)

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        10.524 s
Ran all test suites matching /packages\/generate-persisted-query-manifest\//i.
```

This PR adds the suggestion in the [Jest docs](https://jestjs.io/docs/configuration#prettierpath-string) that installs prettier v2 under the "prettier-2" package and uses it for Jest by configuring the `prettierPath` option in the config.


