### PR TITLE
Update/fix CCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ workflows:
           matrix:
             parameters:
               node-version:
-                - "16.0.0"
+                - "16"
                 - "18"
                 - "20"
       - GraphQL v14 - backcompat

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  node: circleci/node@5.0.2
+  node: circleci/node@5.1.0
 
 commands:
   install-volta:
@@ -75,7 +75,6 @@ jobs:
       - run: npm run lint
 
 workflows:
-  version: 2
   Build:
     jobs:
       - NodeJS:
@@ -83,9 +82,10 @@ workflows:
           matrix:
             parameters:
               node-version:
-                - "16"
+                - "16.0.0"
                 - "18"
                 - "20"
       - GraphQL v14 - backcompat
       - GraphQL v15 - backcompat
       - Prettier
+      - Lint

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true


### PR DESCRIPTION
* bump `node` orb
* remove deprecated `version`
* add missing `Lint` job
* add missing `.npmrc` to enforce engine compat
  * the `make-fetch-happen@13` PR should be failing since we claim support for `>16` and it supports `>16.13` (though it is just a dev dependency)