### PR TITLE
Add `redirect` to `FetcherRequestInit`

### DIFF
--- a/.changeset/nice-boats-shake.md
+++ b/.changeset/nice-boats-shake.md
@@ -1,0 +1,5 @@
+---
+"@apollo/utils.fetcher": minor
+---
+
+Add `redirect` to `FetcherRequestInit`

--- a/packages/fetcher/src/index.ts
+++ b/packages/fetcher/src/index.ts
@@ -5,6 +5,7 @@ export interface FetcherRequestInit {
   // objects.
   headers?: Record<string, string>;
   body?: string | Buffer;
+  redirect?: 'follow' | 'error' | 'manual';
 
   // A provided `signal` should be an object created by a class named
   // `AbortSignal` (the constructor name is checked by some implementations like

--- a/packages/fetcher/src/index.ts
+++ b/packages/fetcher/src/index.ts
@@ -5,7 +5,7 @@ export interface FetcherRequestInit {
   // objects.
   headers?: Record<string, string>;
   body?: string | Buffer;
-  redirect?: 'follow' | 'error' | 'manual';
+  redirect?: "follow" | "error" | "manual";
 
   // A provided `signal` should be an object created by a class named
   // `AbortSignal` (the constructor name is checked by some implementations like


### PR DESCRIPTION
Was present in previous Apollo REST Data Source versions, but seems to be missing on this one. It's part of the Fetch API (https://developer.mozilla.org/en-US/docs/Web/API/Request/redirect), so it should be safe to add here.