### PR TITLE
Add ability to specify custom document transform during manifest generation

### DIFF
--- a/.changeset/dirty-masks-nail.md
+++ b/.changeset/dirty-masks-nail.md
@@ -4,7 +4,11 @@
 
 Add ability to specify a custom document transform used during manifest generation.
 
-NOTE: This should be the same document transform that is passed to your `ApolloClient` instance.
+> [!NOTE]
+> You must be running Apollo Client 3.8.0 or greater to use this feature.
+
+> [!IMPORTANT]
+> This should be the same document transform that is passed to your `ApolloClient` instance, otherwise you risk mismatches in the query output.
 
 ```ts
 // persisted-query-manifest.config.ts

--- a/.changeset/dirty-masks-nail.md
+++ b/.changeset/dirty-masks-nail.md
@@ -1,0 +1,24 @@
+---
+"@apollo/generate-persisted-query-manifest": minor
+---
+
+Add ability to specify a custom document transform used during manifest generation.
+
+NOTE: This should be the same document transform that is passed to your `ApolloClient` instance.
+
+```ts
+// persisted-query-manifest.config.ts
+import { PersistedQueryManifestConfig } from "@apollo/generate-persisted-query-manifest";
+import { DocumentTransform } from "@apollo/client/core";
+
+const documentTransform = new DocumentTransform((document) => {
+  // transform your document
+  return transformedDocument;
+})
+
+const config: PersistedQueryManifestConfig = {
+  documentTransform,
+};
+
+export default config;
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -10512,7 +10512,6 @@
         "generate-persisted-query-manifest": "cli.js"
       },
       "devDependencies": {
-        "@apollo/client": "3.9.5",
         "@gmrchk/cli-testing-library": "0.1.2",
         "@wry/equality": "0.5.7"
       },
@@ -10801,7 +10800,6 @@
     "@apollo/generate-persisted-query-manifest": {
       "version": "file:packages/generate-persisted-query-manifest",
       "requires": {
-        "@apollo/client": "3.9.5",
         "@apollo/persisted-query-lists": "^1.0.0",
         "@gmrchk/cli-testing-library": "0.1.2",
         "@graphql-tools/graphql-tag-pluck": "^8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10512,6 +10512,7 @@
         "generate-persisted-query-manifest": "cli.js"
       },
       "devDependencies": {
+        "@apollo/client": "3.9.5",
         "@gmrchk/cli-testing-library": "0.1.2",
         "@wry/equality": "0.5.7"
       },
@@ -10800,6 +10801,7 @@
     "@apollo/generate-persisted-query-manifest": {
       "version": "file:packages/generate-persisted-query-manifest",
       "requires": {
+        "@apollo/client": "3.9.5",
         "@apollo/persisted-query-lists": "^1.0.0",
         "@gmrchk/cli-testing-library": "0.1.2",
         "@graphql-tools/graphql-tag-pluck": "^8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10520,7 +10520,7 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "@apollo/client": "^3.7.0 || ^3.8.0-alpha",
+        "@apollo/client": "^3.7.0",
         "graphql": "14.x || 15.x || 16.x"
       }
     },

--- a/packages/generate-persisted-query-manifest/README.md
+++ b/packages/generate-persisted-query-manifest/README.md
@@ -162,6 +162,6 @@ const config = {
     // ... transform the document
 
     return transformedDocument;
-  })
-}
+  }),
+};
 ```

--- a/packages/generate-persisted-query-manifest/README.md
+++ b/packages/generate-persisted-query-manifest/README.md
@@ -143,3 +143,25 @@ const config = {
   },
 };
 ```
+
+- `documentTransform` - `DocumentTransform`
+
+An `@apollo/client` `DocumentTransform` instance used to transform GraphQL documents before they are saved to the manifest. Use this option if you pass a `documentTransform` option to your Apollo Client instance.
+
+For more information, see the Apollo Client [Document transforms](https://www.apollographql.com/docs/react/data/document-transforms) documentation.
+
+> NOTE: This feature is only available if you use Apollo Client 3.8.0 or greater.
+
+```ts
+import { DocumentTransform } from "@apollo/client/core";
+
+const config = {
+  // Inlined for this example, but ideally this should be use the same
+  // instance that is shared with your Apollo Client config
+  documentTransform: new DocumentTransform((document) => {
+    // ... transform the document
+
+    return transformedDocument;
+  })
+}
+```

--- a/packages/generate-persisted-query-manifest/README.md
+++ b/packages/generate-persisted-query-manifest/README.md
@@ -156,8 +156,8 @@ For more information, see the Apollo Client [Document transforms](https://www.ap
 import { DocumentTransform } from "@apollo/client/core";
 
 const config = {
-  // Inlined for this example, but ideally this should be use the same
-  // instance that is shared with your Apollo Client config
+  // Inlined for this example, but ideally this should use the same instance
+  // that is passed to your Apollo Client instance
   documentTransform: new DocumentTransform((document) => {
     // ... transform the document
 

--- a/packages/generate-persisted-query-manifest/package.json
+++ b/packages/generate-persisted-query-manifest/package.json
@@ -40,7 +40,6 @@
     "graphql": "14.x || 15.x || 16.x"
   },
   "devDependencies": {
-    "@apollo/client": "3.9.5",
     "@gmrchk/cli-testing-library": "0.1.2",
     "@wry/equality": "0.5.7"
   }

--- a/packages/generate-persisted-query-manifest/package.json
+++ b/packages/generate-persisted-query-manifest/package.json
@@ -40,6 +40,7 @@
     "graphql": "14.x || 15.x || 16.x"
   },
   "devDependencies": {
+    "@apollo/client": "3.9.5",
     "@gmrchk/cli-testing-library": "0.1.2",
     "@wry/equality": "0.5.7"
   }

--- a/packages/generate-persisted-query-manifest/package.json
+++ b/packages/generate-persisted-query-manifest/package.json
@@ -36,7 +36,7 @@
     "vfile-reporter": "^6.0.2"
   },
   "peerDependencies": {
-    "@apollo/client": "^3.7.0 || ^3.8.0-alpha",
+    "@apollo/client": "^3.7.0",
     "graphql": "14.x || 15.x || 16.x"
   },
   "devDependencies": {

--- a/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
+++ b/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
@@ -677,7 +677,7 @@ test("can specify custom document location with config file", async () => {
 
 {
   const ymlConfig = `
-documents: 
+documents:
   - queries/**/*.graphql
 `;
 
@@ -691,7 +691,7 @@ module.exports = {
 import { PersistedQueryManifestConfig } from '@apollo/generate-persisted-query-manifest';
 
 const config: PersistedQueryManifestOperation = {
-  documents: ['queries/**/*.graphql'] 
+  documents: ['queries/**/*.graphql']
 }
 
 export default config;
@@ -895,7 +895,7 @@ const config: PersistedQueryManifestConfig = {
         return Buffer.from(query).toString("base64");
       default:
         return createDefaultId();
-    }  
+    }
   }
 };
 

--- a/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
+++ b/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
@@ -10,7 +10,6 @@ import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import type { PersistedQueryManifestOperation } from "../index";
-import packageJson from "../../package.json";
 
 test("prints help message with --help", async () => {
   const { cleanup, runCommand } = await setup();
@@ -926,7 +925,7 @@ export default config;
   await cleanup();
 });
 
-test("can specify custom document transform in config", async () => {
+test("can specify custom document transform in config using Apollo Client > 3.8", async () => {
   const { cleanup, runCommand, writeFile, readFile, execute } = await setup();
   const query = gql`
     query GreetingQuery {
@@ -950,7 +949,7 @@ test("can specify custom document transform in config", async () => {
     "./package.json",
     JSON.stringify({
       dependencies: {
-        "@apollo/client": packageJson.devDependencies["@apollo/client"],
+        "@apollo/client": "^3.8.0",
       },
     }),
   );

--- a/packages/generate-persisted-query-manifest/src/__tests__/tsconfig.json
+++ b/packages/generate-persisted-query-manifest/src/__tests__/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.base",
-  "compilerOptions": {
-    "resolveJsonModule": true
-  },
-  "include": ["**/*", "../../package.json"],
+  "include": ["**/*"],
   "references": [{ "path": "../../" }]
 }

--- a/packages/generate-persisted-query-manifest/src/__tests__/tsconfig.json
+++ b/packages/generate-persisted-query-manifest/src/__tests__/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../../../tsconfig.test.base",
-  "include": ["**/*"],
+  "compilerOptions": {
+    "resolveJsonModule": true
+  },
+  "include": ["**/*", "../../package.json"],
   "references": [{ "path": "../../" }]
 }

--- a/packages/generate-persisted-query-manifest/src/index.ts
+++ b/packages/generate-persisted-query-manifest/src/index.ts
@@ -33,8 +33,8 @@ import chalk from "chalk";
 type OperationType = "query" | "mutation" | "subscription";
 
 // If the user uses Apollo Client 3.7, `DocumentTransform` won't exist.
-// TypeScript will default the value to `any` in this case. We prefer to set the
-// type as `never` in this situation to complain if the property is set.
+// TypeScript will default the value to `any` in this case. We don't want to
+// allow this property in this case, so we set the type to `never`.
 type DocumentTransform = any extends RealDocumentTransform
   ? never
   : RealDocumentTransform;

--- a/packages/generate-persisted-query-manifest/src/index.ts
+++ b/packages/generate-persisted-query-manifest/src/index.ts
@@ -55,6 +55,19 @@ export interface PersistedQueryManifestConfig {
    * IMPORTANT: You must be running `@apollo/client` 3.8.0 or greater to use
    * this feature.
    *
+   * @example
+   * ```ts
+   * import { DocumentTransform } from "@apollo/client/core";
+   *
+   * const config = {
+   *   documentTransform: new DocumentTransform((document) => {
+   *     // ... transform the document
+   *
+   *     return transformedDocument;
+   *   })
+   * }
+   * ```
+   *
    * @since 1.2.0
    */
   documentTransform?: DocumentTransform;

--- a/packages/generate-persisted-query-manifest/src/index.ts
+++ b/packages/generate-persisted-query-manifest/src/index.ts
@@ -51,6 +51,11 @@ export interface PersistedQueryManifestConfig {
    * For more information about document transforms, see the [Document
    * transforms](https://www.apollographql.com/docs/react/data/document-transforms)
    * documentation page.
+   *
+   * IMPORTANT: You must be running `@apollo/client` 3.8.0 or greater to use
+   * this feature.
+   *
+   * @since 1.2.0
    */
   documentTransform?: DocumentTransform;
 

--- a/packages/generate-persisted-query-manifest/src/index.ts
+++ b/packages/generate-persisted-query-manifest/src/index.ts
@@ -7,6 +7,7 @@ import {
 } from "@apollo/client/core";
 import type {
   ApolloClientOptions,
+  // @ts-ignore
   DocumentTransform as RealDocumentTransform,
 } from "@apollo/client/core";
 import { sortTopLevelDefinitions } from "@apollo/persisted-query-lists";

--- a/packages/generate-persisted-query-manifest/src/index.ts
+++ b/packages/generate-persisted-query-manifest/src/index.ts
@@ -7,7 +7,7 @@ import {
 } from "@apollo/client/core";
 import type {
   ApolloClientOptions,
-  DocumentTransform,
+  DocumentTransform as RealDocumentTransform,
 } from "@apollo/client/core";
 import { sortTopLevelDefinitions } from "@apollo/persisted-query-lists";
 import { gqlPluckFromCodeStringSync } from "@graphql-tools/graphql-tag-pluck";
@@ -30,6 +30,13 @@ import reporter from "vfile-reporter";
 import chalk from "chalk";
 
 type OperationType = "query" | "mutation" | "subscription";
+
+// If the user uses Apollo Client 3.7, `DocumentTransform` won't exist.
+// TypeScript will default the value to `any` in this case. We prefer to set the
+// type as `never` in this situation to complain if the property is set.
+type DocumentTransform = any extends RealDocumentTransform
+  ? never
+  : RealDocumentTransform;
 
 interface CreateOperationIdOptions {
   operationName: string;

--- a/packages/generate-persisted-query-manifest/tsconfig.json
+++ b/packages/generate-persisted-query-manifest/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "removeComments": false
   },
   "include": ["src/**/*"],
   "exclude": ["**/__tests__"],


### PR DESCRIPTION
Apollo Client v3.8 added support for [custom document transforms](https://www.apollographql.com/docs/react/data/document-transforms) that can be used to modify queries before they are sent to the server. This PR adds support for this feature during manifest generation to ensure the queries saved to the manifest match what will be sent by the client in a running app.