### PR TITLE
Better handle errors from the client and detect multiple operations

### DIFF
--- a/.changeset/khaki-birds-tap.md
+++ b/.changeset/khaki-birds-tap.md
@@ -1,0 +1,5 @@
+---
+"@apollo/generate-persisted-query-manifest": patch
+---
+
+Better report errors that originate from Apollo Client during manifest generation.

--- a/.changeset/perfect-lies-protect.md
+++ b/.changeset/perfect-lies-protect.md
@@ -1,0 +1,5 @@
+---
+"@apollo/generate-persisted-query-manifest": patch
+---
+
+Detect multiple operations during manifest generation and report them as errors.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10544,7 +10544,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -10555,8 +10554,7 @@
     "node_modules/lru-cache/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/make-dir": {
       "version": "4.0.0",
@@ -14106,6 +14104,7 @@
         "cosmiconfig-typescript-loader": "^5.0.0",
         "globby": "^11.1.0",
         "lodash": "^4.17.21",
+        "semver": "^7.6.0",
         "vfile": "^4.2.1",
         "vfile-reporter": "^6.0.2"
       },
@@ -14177,6 +14176,20 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "packages/generate-persisted-query-manifest/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "packages/generate-persisted-query-manifest/node_modules/supports-color": {
@@ -14418,6 +14431,7 @@
         "cosmiconfig-typescript-loader": "^5.0.0",
         "globby": "^11.1.0",
         "lodash": "^4.17.21",
+        "semver": "^7.6.0",
         "vfile": "^4.2.1",
         "vfile-reporter": "^6.0.2"
       },
@@ -14456,6 +14470,14 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "semver": {
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+          "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         },
         "supports-color": {
           "version": "7.2.0",
@@ -22117,7 +22139,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       },
@@ -22125,8 +22146,7 @@
         "yallist": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },

--- a/packages/generate-persisted-query-manifest/package.json
+++ b/packages/generate-persisted-query-manifest/package.json
@@ -32,6 +32,7 @@
     "cosmiconfig-typescript-loader": "^5.0.0",
     "globby": "^11.1.0",
     "lodash": "^4.17.21",
+    "semver": "^7.6.0",
     "vfile": "^4.2.1",
     "vfile-reporter": "^6.0.2"
   },

--- a/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
+++ b/packages/generate-persisted-query-manifest/src/__tests__/cli.test.ts
@@ -1423,7 +1423,7 @@ test("does not allow multiple operations in a single document", async () => {
   const { cleanup, runCommand, writeFile } = await setup();
 
   await writeFile(
-    "./src/query.graphql",
+    "./src/queries.graphql",
     `
 query GreetingQuery {
   greeting
@@ -1486,7 +1486,7 @@ subscription TestSubscription {
       "1:1  error  Cannot declare multiple operations in a single document.",
       "src/mutations.graphql",
       "1:1  error  Cannot declare multiple operations in a single document.",
-      "src/query.graphql",
+      "src/queries.graphql",
       "1:1  error  Cannot declare multiple operations in a single document.",
       "src/subscriptions.graphql",
       "1:1  error  Cannot declare multiple operations in a single document.",

--- a/packages/generate-persisted-query-manifest/src/index.ts
+++ b/packages/generate-persisted-query-manifest/src/index.ts
@@ -1,5 +1,6 @@
 import { createFragmentRegistry } from "@apollo/client/cache";
 import type { FragmentRegistryAPI } from "@apollo/client/cache";
+import semver from "semver";
 import {
   ApolloClient,
   ApolloLink,
@@ -262,6 +263,15 @@ const ERROR_MESSAGES = {
     return `${error.name}: ${error.message}`;
   },
 };
+
+async function enableDevMessages() {
+  const { loadDevMessages, loadErrorMessages } = await import(
+    "@apollo/client/dev"
+  );
+
+  loadDevMessages();
+  loadErrorMessages();
+}
 
 function addError(
   source: Pick<DocumentSource, "file"> & Partial<DocumentSource>,
@@ -559,6 +569,10 @@ export async function generatePersistedQueryManifest(
       return Observable.of({ data: null });
     }),
   });
+
+  if (semver.gte(client.version, "3.8.0")) {
+    await enableDevMessages();
+  }
 
   for (const [_, sources] of sortBy([...operationsByName.entries()], first)) {
     for (const source of sources) {

--- a/packages/generate-persisted-query-manifest/src/index.ts
+++ b/packages/generate-persisted-query-manifest/src/index.ts
@@ -403,6 +403,8 @@ async function fromFilepathList(
       continue;
     }
 
+    let documentCount = 0;
+
     visit(source.node, {
       FragmentDefinition(node) {
         const name = node.name.value;
@@ -421,6 +423,11 @@ async function fromFilepathList(
       },
       OperationDefinition(node) {
         const name = node.name?.value;
+
+        if (++documentCount > 1) {
+          addError(source, ERROR_MESSAGES.multipleOperations());
+          return BREAK;
+        }
 
         if (!name) {
           addError(source, ERROR_MESSAGES.anonymousOperation(node));
@@ -500,19 +507,12 @@ export async function generatePersistedQueryManifest(
       continue;
     }
 
-    let documentCount = 0;
-
     // We delegate validation to the functions that return the document sources.
     // We just need to record the operations here to sort them in the manifest
     // output.
     visit(source.node, {
       OperationDefinition(node) {
         const name = node.name?.value;
-
-        if (++documentCount > 1) {
-          addError(source, ERROR_MESSAGES.multipleOperations());
-          return BREAK;
-        }
 
         if (!name) {
           return false;

--- a/packages/generate-persisted-query-manifest/src/index.ts
+++ b/packages/generate-persisted-query-manifest/src/index.ts
@@ -260,7 +260,7 @@ const ERROR_MESSAGES = {
     )}".`;
   },
   parseError(error: Error) {
-    return `${error.name}: ${error.message}`;
+    return formatErrorMessage(error);
   },
 };
 


### PR DESCRIPTION
Fixes #431

Better reports errors if they originate from Apollo Client itself rather than throwing an obscure error during the manifest generation. This change also adds detects multiple operations in a single document and will report those as errors.


