### PR TITLE
createhash: only call module.require if it exists

### DIFF
--- a/.changeset/early-boxes-check.md
+++ b/.changeset/early-boxes-check.md
@@ -1,0 +1,5 @@
+---
+"@apollo/utils.createhash": patch
+---
+
+Compatibility with Next.js Turbopack

--- a/packages/createHash/src/index.ts
+++ b/packages/createHash/src/index.ts
@@ -1,7 +1,13 @@
 import { isNodeLike } from "@apollo/utils.isnodelike";
 
 export function createHash(kind: string): import("crypto").Hash {
-  if (isNodeLike) {
+  // Some Node-like environments (like next.js Turbopack) apparently
+  // don't have module.require, so double-check before we call it.
+  // (But don't the value of isNodeLike because other logic depends on it,
+  // like Apollo Server signal handling defaults.) This does mean that
+  // Turbopack will call sha.js instead of the native crypto module, but
+  // it sure beats throwing because module.require does not exist.
+  if (isNodeLike && module.require) {
     // Use module.require instead of just require to avoid bundling whatever
     // crypto polyfills a non-Node bundler might fall back to.
     return module.require("crypto").createHash(kind);

--- a/packages/createHash/src/index.ts
+++ b/packages/createHash/src/index.ts
@@ -3,7 +3,7 @@ import { isNodeLike } from "@apollo/utils.isnodelike";
 export function createHash(kind: string): import("crypto").Hash {
   // Some Node-like environments (like next.js Turbopack) apparently
   // don't have module.require, so double-check before we call it.
-  // (But don't the value of isNodeLike because other logic depends on it,
+  // (But don't change the value of isNodeLike because other logic depends on it,
   // like Apollo Server signal handling defaults.) This does mean that
   // Turbopack will call sha.js instead of the native crypto module, but
   // it sure beats throwing because module.require does not exist.


### PR DESCRIPTION
Apparently Next.JS "Turbopack" runs code in a weird semi-Node environment that doesn't have module.require. We don't want to call require directly because that makes other bundlers put in polyfills. So make Turbopack use sha.js instead of just throwing. Non-ideal but better than what we have today.

For apollographql/apollo-server#8004